### PR TITLE
harden task file parsing and ci supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Go module dependencies (catches transitive vulnerabilities the moment a
+  # fix is published, complementing the `vulncheck` CI job).
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  # Keeps `uses:` SHA pins in .github/workflows/*.yml fresh. Pair with the
+  # `ghapin` skill when reviewing PRs to ensure new pins stay on full SHAs.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gha:
+        patterns:
+          - "*"
+
+  # Base images and tooling pinned in the Dockerfile (golang, alpine,
+  # tonistiigi/xx, crazymax/osxcross).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Weekly run picks up newly disclosed vulnerabilities even when the repo
+    # is quiet between PRs.
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
@@ -13,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
@@ -22,15 +28,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
 
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          go-package: ./...
+
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - run: >
           docker buildx build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,20 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write     # gh release create
+      id-token: write     # sigstore signing for attestations
+      attestations: write # actions/attest-build-provenance
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build binaries for all platforms
         run: >
@@ -23,6 +28,10 @@ jobs:
           --platform linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
           --output=./dist
           .
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "dist/*/*"
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ CI (`.github/workflows/ci.yml`) runs tests, `golangci-lint`, and the
 multi-platform Docker build. Releases (`release.yml`) are tag-driven and
 publish cross-built binaries via `gh release create`.
 
-The Go toolchain version comes from `go.mod` (`go 1.26.2`). Tests run with
+The Go toolchain version comes from `go.mod` (`go 1.26.3`). Tests run with
 `-tests=true` under golangci-lint v2.
 
 ## Code style and conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.26.2"
+ARG GO_VERSION="1.26.3"
 ARG ALPINE_VERSION="3.22"
 ARG XX_VERSION="1.9.0"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dgageot/gogo
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/alexflint/go-arg v1.6.1

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -1,11 +1,33 @@
 package taskfile
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
 	"slices"
+	"strings"
 )
+
+// validateIncludeName ensures an `includes:` entry resolves to a direct
+// subdirectory of the task file that declares it. Absolute paths,
+// parent-directory escapes ('..'), and path separators are rejected so an
+// include can never reach outside its parent's tree.
+func validateIncludeName(name string) error {
+	if name == "" {
+		return errors.New("include name must not be empty")
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("include %q must be a subdirectory (absolute paths are not allowed)", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("include %q must be a subdirectory (path separators are not allowed)", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("include %q must be a subdirectory ('..' is not allowed)", name)
+	}
+	return nil
+}
 
 // LoadWithIncludes parses a task file and resolves all includes into a flat task map.
 func LoadWithIncludes(dir string) (*Config, error) {
@@ -127,11 +149,13 @@ func (l *includeLoader) loadInclude(req includeRequest) error {
 	}
 
 	l.mergeVars(included.Vars)
-	l.mergeTasks(included)
-	return nil
+	return l.mergeTasks(included)
 }
 
 func (l *includeLoader) parseInclude(req includeRequest) (*includedConfig, error) {
+	if err := validateIncludeName(req.name); err != nil {
+		return nil, fmt.Errorf("%s: %w", req.parentFile(), err)
+	}
 	childDir, err := req.childDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolving include %q from %s: %w", req.namespace, req.parentFile(), err)
@@ -259,8 +283,7 @@ func (l *includeLoader) loadFlatten(req flattenRequest) error {
 	}
 
 	l.mergeVars(flattened.Vars)
-	l.mergeFlattenedTasks(flattened, req.namespace, req.ancestorDir)
-	return nil
+	return l.mergeFlattenedTasks(flattened, req.namespace, req.ancestorDir)
 }
 
 func namespaceJoin(prefix, name string) string {
@@ -285,11 +308,16 @@ func (l *includeLoader) mergeVars(vars map[string]Var) {
 	}
 }
 
-func (l *includeLoader) mergeTasks(included *includedConfig) {
+func (l *includeLoader) mergeTasks(included *includedConfig) error {
 	for _, name := range slices.Sorted(maps.Keys(included.Tasks)) {
 		task := normalizedIncludedTask(included, name)
-		l.root.Tasks[included.Namespace+":"+name] = task
+		finalName := included.Namespace + ":" + name
+		if err := validateTaskName(finalName); err != nil {
+			return err
+		}
+		l.root.Tasks[finalName] = task
 	}
+	return nil
 }
 
 // mergeFlattenedTasks merges tasks from a flattened file into l.root at the
@@ -297,9 +325,12 @@ func (l *includeLoader) mergeTasks(included *includedConfig) {
 // (this is the agentic-platform pattern for splitting one file across many).
 // First defined wins, so a parent file can override a flattened task by
 // declaring it locally with the same name.
-func (l *includeLoader) mergeFlattenedTasks(flattened *Config, namespace, ancestorDir string) {
+func (l *includeLoader) mergeFlattenedTasks(flattened *Config, namespace, ancestorDir string) error {
 	for _, name := range slices.Sorted(maps.Keys(flattened.Tasks)) {
 		finalName := namespaceJoin(namespace, name)
+		if err := validateTaskName(finalName); err != nil {
+			return err
+		}
 		if _, exists := l.root.Tasks[finalName]; exists {
 			continue // first wins (root or earlier flatten file beats this one)
 		}
@@ -311,6 +342,7 @@ func (l *includeLoader) mergeFlattenedTasks(flattened *Config, namespace, ancest
 		}
 		l.root.Tasks[finalName] = task
 	}
+	return nil
 }
 
 func normalizedIncludedTask(included *includedConfig, name string) Task {

--- a/taskfile/parse.go
+++ b/taskfile/parse.go
@@ -5,11 +5,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 )
 
 const fileName = "gogo.yaml"
+
+// validateTaskName rejects task names containing characters that could escape
+// the on-disk checksum directory or otherwise misbehave when joined into a
+// filesystem path. Namespace separators (':') and ordinary identifier
+// characters are allowed; '/', '\\' and '..' are not.
+func validateTaskName(name string) error {
+	if name == "" {
+		return errors.New("task name must not be empty")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("task name %q must not contain '/' or '\\'", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("task name %q must not contain '..'", name)
+	}
+	return nil
+}
 
 // Parse reads and parses a task file from the given directory.
 func Parse(dir string) (*Config, error) {
@@ -29,8 +47,6 @@ func parseFile(path, dir string) (*Config, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	data = expandTemplates(data)
-
 	var tf Config
 	if err := yaml.UnmarshalWithOptions(data, &tf, yaml.Strict()); err != nil {
 		return nil, fmt.Errorf("parsing %s:\n%s", path, yaml.FormatError(err, true, true))
@@ -40,6 +56,16 @@ func parseFile(path, dir string) (*Config, error) {
 	if tf.Tasks == nil {
 		tf.Tasks = make(map[string]Task)
 	}
+
+	for name := range tf.Tasks {
+		if err := validateTaskName(name); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+	}
+
+	// Expand {{.VAR}} env-variable references on parsed string values only,
+	// never on raw bytes — so an env value can't inject YAML structure.
+	expandConfigEnvTemplates(&tf)
 
 	// Extract comments from AST to use as task descriptions
 	applyTaskComments(&tf, data)

--- a/taskfile/parse_test.go
+++ b/taskfile/parse_test.go
@@ -94,7 +94,10 @@ tasks:
 	assert.Contains(t, tf.Tasks, "cli:nested:test")
 }
 
-func TestLoadWithIncludesRejectsCycles(t *testing.T) {
+func TestLoadWithIncludesRejectsParentEscape(t *testing.T) {
+	// `includes:` must point at a direct subdirectory, so `..` (or any path
+	// that climbs out of the parent) is rejected. This makes parent-escape
+	// cycles unreachable: an include cycle would require a parent jump.
 	dir := t.TempDir()
 	writeFiles(t, dir, map[string]string{
 		"gogo.yaml": `version: "1"
@@ -113,8 +116,30 @@ includes:
 
 	_, err := LoadWithIncludes(dir)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cyclic include")
+	assert.Contains(t, err.Error(), "must be a subdirectory")
 	assert.Contains(t, err.Error(), filepath.Join(dir, "cli", "root", "gogo.yaml"))
+}
+
+func TestLoadWithIncludesRejectsNonSubdirectory(t *testing.T) {
+	cases := map[string]string{
+		"parent":      "..",
+		"sibling":     "../sibling",
+		"absolute":    "/etc",
+		"nested-path": "sub/dir",
+		"backslash":   `sub\dir`,
+	}
+	for label, badName := range cases {
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, map[string]string{
+				"gogo.yaml": fmt.Sprintf("version: \"1\"\nincludes:\n  - %q\n", badName),
+			})
+
+			_, err := LoadWithIncludes(dir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must be a subdirectory")
+		})
+	}
 }
 
 func TestLoadWithIncludesMissingMentionsParentFile(t *testing.T) {
@@ -206,12 +231,72 @@ tasks:
 	assert.Contains(t, tf.Tasks, "server:utils:fmt", "nested include under server should be namespaced as server:utils:fmt")
 }
 
-func TestExpandTemplates(t *testing.T) {
+func TestExpandEnvTemplatesValueOnly(t *testing.T) {
 	t.Setenv("MY_VAR", "hello")
 
-	assert.Equal(t, []byte("value: hello"), expandTemplates([]byte("value: {{.MY_VAR}}")))
-	assert.Equal(t, []byte("value: hello"), expandTemplates([]byte("value: {{ .MY_VAR }}")))
-	assert.Equal(t, []byte("value: {{.UNSET_VAR}}"), expandTemplates([]byte("value: {{.UNSET_VAR}}")))
+	assert.Equal(t, "value: hello", expandEnvTemplates("value: {{.MY_VAR}}"))
+	assert.Equal(t, "value: hello", expandEnvTemplates("value: {{ .MY_VAR }}"))
+	assert.Equal(t, "value: {{.UNSET_VAR}}", expandEnvTemplates("value: {{.UNSET_VAR}}"))
+}
+
+func TestParseEnvExpansionAppliesToValuesNotStructure(t *testing.T) {
+	// An env value containing YAML-structural characters (newline, ':', '-')
+	// must NOT be able to inject new tasks or fields. The substitution happens
+	// after YAML parsing, so the parser sees the original document.
+	t.Setenv("GOGO_INJECT", "injected\n  evil:\n    cmd: rm -rf /")
+
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+tasks:
+  build:
+    cmd: echo {{.GOGO_INJECT}}
+`,
+	})
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	// The malicious env value lands inside the cmd string verbatim — no
+	// 'evil' task is conjured into existence.
+	assert.NotContains(t, tf.Tasks, "evil")
+	require.Contains(t, tf.Tasks, "build")
+	require.Len(t, tf.Tasks["build"].Cmds, 1)
+	assert.Equal(t,
+		"echo injected\n  evil:\n    cmd: rm -rf /",
+		tf.Tasks["build"].Cmds[0].Cmd,
+	)
+}
+
+func TestParseEnvExpansionInVariousFields(t *testing.T) {
+	// Verify the documented "expand {{.VAR}} from env at parse time" behavior
+	// still works for the common user-configurable string fields.
+	t.Setenv("GOGO_TARGET", "prod")
+	t.Setenv("GOGO_DIR", "backend")
+	t.Setenv("GOGO_VERSION", "1.2.3")
+
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+vars:
+  RELEASE: "v{{.GOGO_VERSION}}"
+tasks:
+  build:
+    dir: "{{.GOGO_DIR}}"
+    env:
+      TARGET: "{{.GOGO_TARGET}}"
+    cmd: echo {{.GOGO_TARGET}}
+`,
+	})
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v1.2.3", tf.Vars["RELEASE"].Value)
+	build := tf.Tasks["build"]
+	assert.Equal(t, "backend", build.Dir)
+	assert.Equal(t, "prod", build.Env["TARGET"])
+	assert.Equal(t, "echo prod", build.Cmds[0].Cmd)
 }
 
 func TestParsePreconditions(t *testing.T) {
@@ -664,4 +749,47 @@ flatten:
 	tf, err := Parse(dir)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"tasks/a.yml", "tasks/b.yml"}, tf.Flatten)
+}
+
+func TestParseRejectsUnsafeTaskNames(t *testing.T) {
+	// Names containing path separators or '..' could be used to escape the
+	// .gogo/checksum/ directory when joined with checksumPath.
+	cases := map[string]string{
+		"slash":      "foo/bar",
+		"backslash":  `foo\bar`,
+		"parent":     "..",
+		"traversal":  "../etc/passwd",
+		"dotdot-mid": "foo..bar",
+	}
+	for label, name := range cases {
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, map[string]string{
+				"gogo.yaml": fmt.Sprintf("version: \"1\"\ntasks:\n  %q:\n    cmd: echo hi\n", name),
+			})
+
+			_, err := Parse(dir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "task name")
+		})
+	}
+}
+
+func TestLoadWithFlattenRejectsUnsafeTaskName(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+flatten:
+  - tasks/extras.yml
+`,
+		"tasks/extras.yml": `version: "1"
+tasks:
+  "../escape":
+    cmd: echo hi
+`,
+	})
+
+	_, err := LoadWithIncludes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task name")
 }

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -11,15 +11,81 @@ import (
 
 var templatePattern = regexp.MustCompile(`\{\{\s*\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
 
-// expandTemplates replaces {{.VAR}} patterns with environment variable values.
-func expandTemplates(data []byte) []byte {
-	return templatePattern.ReplaceAllFunc(data, func(match []byte) []byte {
-		name := string(templatePattern.FindSubmatch(match)[1])
+// expandEnvTemplates replaces {{.VAR}} references in s with values from the
+// process environment. Unknown templates are left verbatim. This is the
+// post-parse equivalent of substituting at the byte level: it only touches
+// user-supplied string values, never YAML structure or map keys, so an env
+// value containing newlines, quotes, or `:` cannot inject new tasks/fields.
+func expandEnvTemplates(s string) string {
+	return templatePattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := templatePattern.FindStringSubmatch(match)[1]
 		if val, ok := os.LookupEnv(name); ok {
-			return []byte(val)
+			return val
 		}
 		return match
 	})
+}
+
+// expandConfigEnvTemplates expands {{.VAR}} env-variable references in every
+// user-configurable string field of a parsed Config. Map keys (task names,
+// var names, env keys) are left untouched so an environment value can never
+// alter the document's structure.
+func expandConfigEnvTemplates(c *Config) {
+	expandStringSlice(c.Includes)
+	expandStringSlice(c.Flatten)
+	expandStringSlice(c.Dotenv)
+	c.Interval = expandEnvTemplates(c.Interval)
+	expandVarsMap(c.Vars)
+	for name, t := range c.Tasks {
+		expandTaskTemplates(&t)
+		c.Tasks[name] = t
+	}
+}
+
+// expandStringSlice rewrites each entry in place. Works for both []string
+// and named slice types like StringList because slice headers share storage.
+func expandStringSlice(s []string) {
+	for i, v := range s {
+		s[i] = expandEnvTemplates(v)
+	}
+}
+
+func expandVarsMap(m map[string]Var) {
+	for k, v := range m {
+		v.Value = expandEnvTemplates(v.Value)
+		v.Sh = expandEnvTemplates(v.Sh)
+		m[k] = v
+	}
+}
+
+func expandTaskTemplates(t *Task) {
+	t.Dir = expandEnvTemplates(t.Dir)
+	expandStringSlice(t.Sources)
+	expandStringSlice(t.Generates)
+	expandStringSlice(t.Aliases)
+	expandStringSlice(t.Platforms)
+	expandStringSlice(t.Dotenv)
+	expandStringSlice(t.Requires.Vars)
+	expandStringSlice(t.Requires.Env)
+	for k, v := range t.Env {
+		t.Env[k] = expandEnvTemplates(v)
+	}
+	expandVarsMap(t.Vars)
+	for i, c := range t.Cmds {
+		c.Cmd = expandEnvTemplates(c.Cmd)
+		c.Task = expandEnvTemplates(c.Task)
+		expandVarsMap(c.Vars)
+		t.Cmds[i] = c
+	}
+	for i, d := range t.Deps {
+		d.Task = expandEnvTemplates(d.Task)
+		t.Deps[i] = d
+	}
+	for i, p := range t.Preconditions {
+		p.Sh = expandEnvTemplates(p.Sh)
+		p.Msg = expandEnvTemplates(p.Msg)
+		t.Preconditions[i] = p
+	}
 }
 
 // resolveAllVars computes the effective variables for a task, including extra vars from call sites.
@@ -84,7 +150,7 @@ func (r *Runner) resolveVar(v Var, dir string) (string, error) {
 // expandVars substitutes template and shell variables in a command string.
 // {{.VAR}} and ${VAR} are both resolved from task variables, CLI_ARGS, and environment.
 // Unknown ${VAR} references are left for the shell to expand. Unknown
-// {{.VAR}} templates are left verbatim (matching expandTemplates at parse time).
+// {{.VAR}} templates are left verbatim (matching expandConfigEnvTemplates at parse time).
 //
 // CLI_ARGS resolves through the same lookup as any other variable: a value
 // in `vars` (e.g. a call-site `vars: { CLI_ARGS: -f }`) wins, and the cliArgs
@@ -111,7 +177,7 @@ func expandVars(s string, vars map[string]string, cliArgs string) string {
 	})
 
 	// Then replace {{.VAR}} templates. Unknown templates are left as-is so
-	// run-time behavior matches expandTemplates at parse time.
+	// run-time behavior matches expandConfigEnvTemplates at parse time.
 	return templatePattern.ReplaceAllStringFunc(s, func(match string) string {
 		key := templatePattern.FindStringSubmatch(match)[1]
 		if val, ok := lookup(key); ok {


### PR DESCRIPTION
A batch of defense-in-depth fixes from a security review. No documented feature changes.

## Task file parsing

- **Task names** containing `/`, `\`, or `..` are rejected at parse time (and again on namespace-composed names from `includes:` / `flatten:`). They flowed straight into `.gogo/checksum/<name>` paths, so a hostile name could write outside the cache dir.
- **`includes:`** entries must now resolve to a direct subdirectory of the file declaring them. Absolute paths, `..`, and path separators are refused with a clear error pointing at the parent file.
- **`{{.VAR}}` expansion** moved off the raw YAML byte stream onto post-parse string fields (cmd, var, env values, dir, sources/generates, dotenv paths, preconditions, …). Map keys are intentionally not expanded, so an env value containing newlines / `:` / quotes can no longer inject new tasks or fields.

## CI / release supply chain

- New `vulncheck` job (`golang/govulncheck-action`) on push, PR, and a weekly cron.
- `persist-credentials: false` on every `actions/checkout` step.
- `release.yml`: workflow-level `permissions: contents: read`, with `contents: write` + `id-token: write` + `attestations: write` only on the release job. Added `actions/attest-build-provenance` to sign every `dist/*/*` artifact (SLSA provenance attached to the release).
- New `.github/dependabot.yml` for `gomod`, `github-actions`, and `docker` (the Dockerfile pins `golang`, `alpine`, `tonistiigi/xx`, `crazymax/osxcross`).

## Toolchain

Bumped Go 1.26.2 → 1.26.3 in `go.mod`, `Dockerfile`, and `AGENTS.md`. The new vulncheck job initially flagged two reachable `net/mail` stdlib vulns (GO-2026-4986, GO-2026-4977) via `arg.Parser.Parse → mail.ParseAddress`; the patch release closes both. `govulncheck ./...` now reports clean.

## Verification

- `go build ./...` ok
- `go test ./...` ok
- `golangci-lint run ./...` 0 issues
- `govulncheck ./...` no vulnerabilities

New tests cover task-name rejection, subdir-only includes, and a YAML-injection regression test that asserts a malicious env value (`\n  evil:\n    cmd: rm -rf /`) cannot create an `evil` task.