### PR TITLE
Add named source presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,13 @@ tasks:
 
   build:
     cmd: go build -o bin/myapp ./...
-    sources:
-      - "**/*.go"
-      - go.mod
+    sources: go            # built-in preset: **/*.go + go.mod + go.sum
     generates:
       - bin/myapp
 
   test:
     cmd: go test ./...
-    sources:
-      - "**/*.go"
+    sources: go
 ```
 
 Run a task:
@@ -59,6 +56,7 @@ gogo -n build
 ## Features
 
 - **Incremental builds** via source checksums or timestamp-based `sources`/`generates`
+- **Source presets** — reuse named glob lists (built-in `go`, or define your own)
 - **Watch mode** for automatic re-runs on file changes
 - **Concurrent dependencies** with automatic deduplication
 - **Variables** with template expansion and shell commands

--- a/docs/features/sources-checksums/index.md
+++ b/docs/features/sources-checksums/index.md
@@ -58,6 +58,60 @@ Patterns containing `**` are matched recursively across all subdirectories (hidd
 | `**/*.go` | All Go files in any subdirectory |
 | `**/*.proto` | All proto files recursively |
 
+## Presets
+
+The same source list — `**/*.go`, `go.mod`, `go.sum` — is repeated on every Go build/lint/test task. Source **presets** let you name a list once and reference it by name:
+
+```yaml
+sources:
+  lint: [go, .golangci.yml]    # composes the built-in `go` preset with one literal
+
+tasks:
+  build:
+    cmd: go build ./...
+    sources: go                # short form: a single name
+  test:
+    cmd: go test ./...
+    sources: go
+  lint:
+    cmd: golangci-lint run
+    sources: lint              # references the user-defined preset above
+  format:
+    cmd: goimports -w .
+    sources: "**/*.go"         # plain globs still work
+```
+
+A `sources:` entry that has **no glob characters** (`*`, `?`, `[`, `]`, `/`, `\`) is looked up in the preset map first; if no preset matches, it's treated as a literal path. So `go.mod` and `.golangci.yml` continue to work as bare filenames.
+
+### Built-in Presets
+
+gogo ships with two built-ins. User-defined entries with the same name win.
+
+| Preset | Expands to |
+|--------|-----------|
+| `go` | `**/*.go`, `go.mod`, `go.sum` |
+| `go-vendored` | the `go` preset, plus `vendor/**` |
+
+### Composition
+
+Presets can reference other presets — the resolver expands recursively, deduplicates, and rejects cycles:
+
+```yaml
+sources:
+  go-strict: [go, .golangci.yml, .editorconfig]
+  ci: [go-strict, scripts/**]
+```
+
+### Overriding a Built-in
+
+Define a preset with the same name to replace the built-in:
+
+```yaml
+sources:
+  # This project doesn't track go.sum.
+  go: ["**/*.go", "go.mod"]
+```
+
 ## Checksum Storage
 
 Checksums are stored in `.gogo/checksum/` relative to the task file directory. You should add `.gogo/` to your `.gitignore`:

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -15,6 +15,7 @@ gogo reads task definitions from a `gogo.yaml` file in the current directory.
 | `flatten` | list of strings | YAML files whose tasks merge into the current namespace without a prefix (see [Includes](../includes/#flatten)) |
 | `dotenv` | list of strings | Paths to `.env` files to load |
 | `vars` | map | Global variables |
+| `sources` | map | Named source-pattern presets, referenced by task `sources:` (see [Sources & Checksums](../sources-checksums/#presets)) |
 | `interval` | string | Default polling interval for watch mode (e.g. `500ms`) |
 | `tasks` | map | Task definitions (see below) |
 
@@ -31,7 +32,7 @@ Each task supports the following fields:
 | `dotenv` | list | Paths to `.env` files to load for this task |
 | `env` | map | Environment variables (supports `op://` references for 1Password secrets) |
 | `vars` | map | Task-scoped variables |
-| `sources` | list | Glob patterns for incremental builds and watch mode |
+| `sources` | list or string | Glob patterns for incremental builds and watch mode. A bare name resolves to a [source preset](../sources-checksums/#presets) (e.g. `sources: go`) |
 | `generates` | list | Output file patterns for timestamp-based incremental builds |
 | `aliases` | list | Alternative names for the task |
 | `platforms` | list | Restrict task to specific OS/arch (e.g. `linux`, `darwin/arm64`) |

--- a/docs/features/watch-mode/index.md
+++ b/docs/features/watch-mode/index.md
@@ -29,9 +29,7 @@ interval: 1s
 tasks:
   test:
     cmd: go test ./...
-    sources:
-      - "*.go"
-      - "cmd/*.go"
+    sources: go
 ```
 
 The `interval` field accepts any Go duration string: `100ms`, `1s`, `2s`, etc.
@@ -43,10 +41,7 @@ The `interval` field accepts any Go duration string: `100ms`, `1s`, `2s`, etc.
 tasks:
   test:
     cmd: go test ./...
-    sources:
-      - "*.go"
-      - "cmd/*.go"
-      - go.mod
+    sources: go     # built-in preset — see Sources & Checksums
 ```
 
 ```sh

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -15,13 +15,12 @@ tasks:
   # Build the project
   build:
     cmd: go build ./...
+    sources: go     # built-in preset: **/*.go + go.mod + go.sum
 
   # Run tests
   test:
     cmd: go test ./...
-    sources:
-      - "*.go"
-      - "cmd/*.go"
+    sources: go
 ```
 
 Run a task:

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,14 +52,13 @@ tasks:
   # Build the project
   build:
     cmd: go build ./...
+    sources: go        # built-in preset: **/*.go + go.mod + go.sum
 
   # Run all tests
   test:
     deps: [build]
     cmd: go test ./...
-    sources:
-      - "*.go"
-      - "cmd/*.go"
+    sources: go
 
   # Format and lint
   lint:

--- a/gogo.yaml
+++ b/gogo.yaml
@@ -1,5 +1,11 @@
 version: "1"
 
+# Named source presets, referenced from each task's `sources:` field by name.
+# `go` is also a built-in preset (**/*.go + go.mod + go.sum); the entry below
+# extends it with the lint config so a .golangci.yml change re-runs `lint`.
+sources:
+  lint: [go, .golangci.yml]
+
 tasks:
   # Build, lint, and test
   default:
@@ -8,56 +14,36 @@ tasks:
   # Build, lint, and test on source changes
   dev:
     deps: [build, lint, test]
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
+    sources: go
 
   # Build the binary
   build:
-    cmds:
-      - go build -trimpath -ldflags "-s -w" -o bin/gogo .
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
+    cmd: go build -trimpath -ldflags "-s -w" -o bin/gogo .
+    sources: go
 
   # Remove build artifacts
   clean:
-    cmds:
-      - rm -rf bin
+    cmd: rm -rf bin
 
   # Run linters
   lint:
-    cmds:
-      - golangci-lint run
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
-      - .golangci.yml
+    cmd: golangci-lint run
+    sources: lint
 
   # Run tests
   test:
-    cmds:
-      - go test ./...
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
+    cmd: go test ./...
+    sources: go
 
   # Format Go source files
   format:
-    cmds:
-      - goimports -w .
-    sources:
-      - "**/*.go"
+    cmd: goimports -w .
+    sources: "**/*.go"
 
   # Cross-compile for all platforms
   build-cross:
-    cmds:
-      - >
-        docker buildx build
-        --target=cross
-        --platform linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
-        .
+    cmd: >
+      docker buildx build
+      --target=cross
+      --platform linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
+      .

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -149,6 +149,7 @@ func (l *includeLoader) loadInclude(req includeRequest) error {
 	}
 
 	l.mergeVars(included.Vars)
+	l.mergeSourcePresets(included.Sources)
 	return l.mergeTasks(included)
 }
 
@@ -283,6 +284,7 @@ func (l *includeLoader) loadFlatten(req flattenRequest) error {
 	}
 
 	l.mergeVars(flattened.Vars)
+	l.mergeSourcePresets(flattened.Sources)
 	return l.mergeFlattenedTasks(flattened, req.namespace, req.ancestorDir)
 }
 
@@ -304,6 +306,22 @@ func (l *includeLoader) mergeVars(vars map[string]Var) {
 	for k, v := range vars {
 		if _, exists := l.root.Vars[k]; !exists {
 			l.root.Vars[k] = v
+		}
+	}
+}
+
+// mergeSourcePresets merges child source presets into the root. Root presets
+// win conflicts, mirroring the precedence used by mergeVars.
+func (l *includeLoader) mergeSourcePresets(presets map[string]StringList) {
+	if len(presets) == 0 {
+		return
+	}
+	if l.root.Sources == nil {
+		l.root.Sources = make(map[string]StringList)
+	}
+	for k, v := range presets {
+		if _, exists := l.root.Sources[k]; !exists {
+			l.root.Sources[k] = v
 		}
 	}
 }

--- a/taskfile/sources.go
+++ b/taskfile/sources.go
@@ -1,0 +1,103 @@
+package taskfile
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// builtinSourcePresets returns gogo's built-in named source groups. They can
+// be overridden by user-defined entries in the top-level `sources:` map —
+// user entries always win on a name collision.
+//
+// The default set focuses on Go projects because that's by far the most
+// duplicated boilerplate today. Presets compose: `go-vendored` references
+// `go` and adds `vendor/**`.
+func builtinSourcePresets() map[string]StringList {
+	return map[string]StringList{
+		"go":          {"**/*.go", "go.mod", "go.sum"},
+		"go-vendored": {"go", "vendor/**"},
+	}
+}
+
+// effectivePresets merges user-defined presets on top of the built-ins.
+// A nil user map yields just the built-ins.
+func effectivePresets(user map[string]StringList) map[string]StringList {
+	merged := builtinSourcePresets()
+	maps.Copy(merged, user)
+	return merged
+}
+
+// resolveSources expands a list of `sources:` entries into a flat list of
+// glob patterns. An entry that matches a known preset name is recursively
+// expanded; anything else is treated as a literal glob.
+//
+// Cycles and unknown names that look like presets are caught here. The result
+// is deduplicated while preserving first-seen order.
+func resolveSources(presets map[string]StringList, list []string) ([]string, error) {
+	if len(list) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(list))
+	seen := make(map[string]struct{})
+	if err := expandSources(presets, list, &out, seen, nil); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// expandSources is the recursive worker behind resolveSources. The visiting
+// stack tracks preset names currently being expanded so we can report cycles.
+func expandSources(presets map[string]StringList, list []string, out *[]string, seen map[string]struct{}, visiting []string) error {
+	for _, entry := range list {
+		if entry == "" {
+			continue
+		}
+		if !looksLikePresetName(entry) {
+			appendUnique(out, seen, entry)
+			continue
+		}
+		preset, ok := presets[entry]
+		if !ok {
+			// No preset matches but the name has no glob characters. Treat as
+			// a literal path — keeps backward compatibility with entries like
+			// "go.mod" or ".golangci.yml" that happen to be plain filenames.
+			appendUnique(out, seen, entry)
+			continue
+		}
+		if slices.Contains(visiting, entry) {
+			return fmt.Errorf("cyclic source preset %q (chain: %s)", entry, strings.Join(append(visiting, entry), " -> "))
+		}
+		if err := expandSources(presets, []string(preset), out, seen, append(visiting, entry)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// looksLikePresetName reports whether s could be a preset reference rather
+// than a glob. Anything containing a glob metacharacter or path separator is
+// definitely a glob; the rest is *eligible* to look up in the preset map.
+func looksLikePresetName(s string) bool {
+	return !strings.ContainsAny(s, "*?[]/\\")
+}
+
+func appendUnique(out *[]string, seen map[string]struct{}, s string) {
+	if _, ok := seen[s]; ok {
+		return
+	}
+	seen[s] = struct{}{}
+	*out = append(*out, s)
+}
+
+// taskSources resolves task.Sources against the config's preset map (with
+// built-ins applied). It returns the original list verbatim on error so
+// callers can surface meaningful diagnostics — but the only errors here are
+// cyclic preset definitions, which we want to fail loudly.
+func (c *Config) taskSources(sources []string) ([]string, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	return resolveSources(effectivePresets(c.Sources), sources)
+}

--- a/taskfile/sources_test.go
+++ b/taskfile/sources_test.go
@@ -1,0 +1,212 @@
+package taskfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSourcesBuiltinGo(t *testing.T) {
+	got, err := resolveSources(builtinSourcePresets(), []string{"go"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum"}, got)
+}
+
+func TestResolveSourcesBuiltinGoVendoredComposesGo(t *testing.T) {
+	got, err := resolveSources(builtinSourcePresets(), []string{"go-vendored"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum", "vendor/**"}, got)
+}
+
+func TestResolveSourcesUnknownNameTreatedAsLiteral(t *testing.T) {
+	// "go.mod" has no glob characters and isn't a preset name — keep as-is so
+	// existing files like "go.mod" or ".golangci.yml" still work without
+	// users having to invent presets for them.
+	got, err := resolveSources(builtinSourcePresets(), []string{"go.mod", ".golangci.yml"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"go.mod", ".golangci.yml"}, got)
+}
+
+func TestResolveSourcesGlobsArePreservedVerbatim(t *testing.T) {
+	got, err := resolveSources(builtinSourcePresets(), []string{"**/*.proto", "cmd/*.go"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.proto", "cmd/*.go"}, got)
+}
+
+func TestResolveSourcesMixedPresetAndLiterals(t *testing.T) {
+	presets := builtinSourcePresets()
+	presets["lint"] = StringList{"go", ".golangci.yml"}
+
+	got, err := resolveSources(presets, []string{"lint"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum", ".golangci.yml"}, got)
+}
+
+func TestResolveSourcesUserOverridesBuiltin(t *testing.T) {
+	user := map[string]StringList{"go": {"**/*.go"}} // strip go.mod/go.sum
+	got, err := resolveSources(effectivePresets(user), []string{"go"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go"}, got)
+}
+
+func TestResolveSourcesDeduplicates(t *testing.T) {
+	presets := map[string]StringList{
+		"a": {"**/*.go", "go.mod"},
+		"b": {"go.mod", "go.sum"},
+	}
+	got, err := resolveSources(effectivePresets(presets), []string{"a", "b", "**/*.go"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum"}, got)
+}
+
+func TestResolveSourcesCycleIsRejected(t *testing.T) {
+	presets := map[string]StringList{
+		"a": {"b"},
+		"b": {"a"},
+	}
+	_, err := resolveSources(presets, []string{"a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cyclic source preset")
+	assert.Contains(t, err.Error(), "a -> b -> a")
+}
+
+func TestResolveSourcesEmptyEntriesSkipped(t *testing.T) {
+	got, err := resolveSources(builtinSourcePresets(), []string{"", "go"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum"}, got)
+}
+
+func TestParseTopLevelSourcesField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+sources:
+  lint:
+    - go
+    - .golangci.yml
+tasks:
+  lint:
+    cmd: golangci-lint run
+    sources:
+      - lint
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, StringList{"go", ".golangci.yml"}, tf.Sources["lint"])
+	assert.Equal(t, StringList{"lint"}, tf.Tasks["lint"].Sources)
+
+	resolved, err := tf.taskSources([]string(tf.Tasks["lint"].Sources))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum", ".golangci.yml"}, resolved)
+}
+
+func TestParseTaskSourcesAcceptsBareString(t *testing.T) {
+	// `sources: go` is the short form; StringList already supports it via its
+	// custom UnmarshalYAML, but make sure the preset resolver follows it.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+tasks:
+  build:
+    cmd: go build .
+    sources: go
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	resolved, err := tf.taskSources([]string(tf.Tasks["build"].Sources))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "go.sum"}, resolved)
+}
+
+func TestSourcesChecksumWithGoPresetDetectsChange(t *testing.T) {
+	// End-to-end sanity check: a task using `sources: go` must invalidate
+	// when a Go file changes, even though the preset is referenced by name.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"main.go":    "package main",
+		"go.mod":     "module test",
+		"go.sum":     "",
+		"sub/lib.go": "package lib",
+	})
+
+	cfg := &Config{} // no user presets — built-ins only
+	resolved, err := cfg.taskSources([]string{"go"})
+	require.NoError(t, err)
+
+	sum1, err := sourcesChecksum(dir, resolved)
+	require.NoError(t, err)
+	require.NotEmpty(t, sum1)
+
+	writeFiles(t, dir, map[string]string{"sub/lib.go": "package lib2"})
+
+	sum2, err := sourcesChecksum(dir, resolved)
+	require.NoError(t, err)
+	assert.NotEqual(t, sum1, sum2)
+}
+
+func TestLoadWithIncludesMergesSourcePresetsRootWins(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+includes:
+  - cli
+sources:
+  shared: ["**/*.go", "go.mod"]
+`,
+		"cli/gogo.yaml": `version: "1"
+sources:
+  shared: ["should-lose"]
+  cli-only: ["**/cli/*.go"]
+tasks:
+  build:
+    cmd: go build .
+    sources: [shared, cli-only]
+`,
+	})
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, StringList{"**/*.go", "go.mod"}, tf.Sources["shared"], "root preset wins")
+	assert.Equal(t, StringList{"**/cli/*.go"}, tf.Sources["cli-only"], "include preset is merged in")
+
+	resolved, err := tf.taskSources([]string(tf.Tasks["cli:build"].Sources))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"**/*.go", "go.mod", "**/cli/*.go"}, resolved)
+}
+
+func TestRunnerSkipsTaskWithUnchangedPresetSources(t *testing.T) {
+	// Integration test: a task using `sources: go` becomes "up to date" after
+	// a successful run, the same way a literal source list would.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"main.go": "package main",
+		"go.mod":  "module test",
+		"go.sum":  "",
+	})
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds:    []Cmd{{Cmd: "true"}},
+				Sources: StringList{"go"},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+
+	require.NoError(t, r.Run("build", ""))
+	r.ResetRan()
+
+	// Second invocation must short-circuit on the stored checksum.
+	execs := captureExecs(r)
+	*execs = nil
+	require.NoError(t, r.Run("build", ""))
+	assert.Empty(t, *execs, "second run should be skipped as up-to-date")
+}

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -2,16 +2,17 @@ package taskfile
 
 // Config represents a parsed gogo.yaml.
 type Config struct {
-	Version    string            `yaml:"version"`
-	Includes   []string          `yaml:"includes"`
-	Flatten    []string          `yaml:"flatten"` // YAML files whose tasks merge into this config without a namespace
-	Dotenv     []string          `yaml:"dotenv"`
-	Vars       map[string]Var    `yaml:"vars"`
-	Tasks      map[string]Task   `yaml:"tasks"`
-	Dir        string            `yaml:"-"`
-	Interval   string            `yaml:"interval"`
-	Namespaces map[string]string `yaml:"-"` // dir -> namespace
-	DotenvVars map[string]string `yaml:"-"` // resolved dotenv variables
+	Version    string                `yaml:"version"`
+	Includes   []string              `yaml:"includes"`
+	Flatten    []string              `yaml:"flatten"` // YAML files whose tasks merge into this config without a namespace
+	Dotenv     []string              `yaml:"dotenv"`
+	Vars       map[string]Var        `yaml:"vars"`
+	Sources    map[string]StringList `yaml:"sources"` // named source presets, referenced from task.Sources by name
+	Tasks      map[string]Task       `yaml:"tasks"`
+	Dir        string                `yaml:"-"`
+	Interval   string                `yaml:"interval"`
+	Namespaces map[string]string     `yaml:"-"` // dir -> namespace
+	DotenvVars map[string]string     `yaml:"-"` // resolved dotenv variables
 }
 
 // Task represents a single task definition.

--- a/taskfile/uptodate.go
+++ b/taskfile/uptodate.go
@@ -11,13 +11,18 @@ func (r *Runner) isUpToDate(task *Task, dir, taskName string, force bool) (bool,
 		return false, "", nil
 	}
 
+	sources, err := r.tf.taskSources([]string(task.Sources))
+	if err != nil {
+		return false, "", fmt.Errorf("resolving sources for task %q: %w", taskName, err)
+	}
+
 	// When generates is set, use timestamp-based comparison
 	if len(task.Generates) > 0 {
-		upToDate, err := outputsNewerThanSources(dir, task.Sources, task.Generates)
+		upToDate, err := outputsNewerThanSources(dir, sources, task.Generates)
 		return upToDate, "", err
 	}
 
-	checksum, err := sourcesChecksum(dir, task.Sources)
+	checksum, err := sourcesChecksum(dir, sources)
 	if err != nil {
 		return false, "", fmt.Errorf("computing sources checksum: %w", err)
 	}

--- a/taskfile/watch.go
+++ b/taskfile/watch.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"slices"
 	"time"
 )
 
@@ -18,7 +17,10 @@ type dirPatterns struct {
 }
 
 // collectSources gathers all source patterns from the task and its dependencies (recursively),
-// preserving each task's working directory.
+// preserving each task's working directory. Preset references in task.Sources
+// are expanded against the config's preset map (with built-ins applied).
+// Tasks whose sources fail to resolve are silently skipped — the actual
+// run-time error is surfaced by isUpToDate.
 func (r *Runner) collectSources(taskName string, visited map[string]struct{}) []dirPatterns {
 	if _, ok := visited[taskName]; ok {
 		return nil
@@ -32,10 +34,12 @@ func (r *Runner) collectSources(taskName string, visited map[string]struct{}) []
 
 	var result []dirPatterns
 	if len(task.Sources) > 0 {
-		result = append(result, dirPatterns{
-			Dir:      r.taskDir(&task),
-			Patterns: slices.Clone([]string(task.Sources)),
-		})
+		if resolved, err := r.tf.taskSources([]string(task.Sources)); err == nil && len(resolved) > 0 {
+			result = append(result, dirPatterns{
+				Dir:      r.taskDir(&task),
+				Patterns: resolved,
+			})
+		}
 	}
 	for _, dep := range task.Deps {
 		resolved, ok := r.resolveTaskName(dep.Task)


### PR DESCRIPTION
## What

Adds **named source presets** to `gogo.yaml` so a task can write `sources: go` instead of repeating

```yaml
sources:
  - "**/*.go"
  - go.mod
  - go.sum
```

on every Go build/lint/test task.

## Why

Across ~25 `gogo.yaml` files in production use, the single most repeated block is the Go source glob list — typically copied 4× per file. It also makes adding `vendor/**` or `.golangci.yml` a multi-line, multi-task edit.

## How it works

- New top-level `sources:` map declares named presets.
- Task `sources:` entries with no glob characters (`*?[]/\`) are looked up in that map; matches expand recursively.
- Built-ins ship by default (user entries override on collision):
  | Preset | Expands to |
  |---|---|
  | `go` | `**/*.go`, `go.mod`, `go.sum` |
  | `go-vendored` | `go` + `vendor/**` |
- Presets compose, dedupe, and reject cycles.
- Unknown bare names are kept as literal paths — so `go.mod` and `.golangci.yml` continue to work without being declared as presets.

### Example

```yaml
sources:
  lint: [go, .golangci.yml]    # composes the built-in `go` preset

tasks:
  build:
    cmd: go build ./...
    sources: go
  test:
    cmd: go test ./...
    sources: go
  lint:
    cmd: golangci-lint run
    sources: lint
```

## Backward compatibility

Fully backward compatible. Existing literal source lists keep working unchanged. The only new lookup happens for bare-name entries, which previously would have been treated as literal filenames — and still are when no preset matches.

## Changes

- **`taskfile/sources.go`** — preset resolution (built-ins, expansion, cycle detection, dedup).
- **`taskfile/types.go`** — `Sources map[string]StringList` on `Config`.
- **`taskfile/uptodate.go`**, **`taskfile/watch.go`** — call the resolver before checksum/timestamp/watch.
- **`taskfile/includes.go`** — merge presets from `includes:` and `flatten:` files (root wins, mirrors `mergeVars`).
- **`taskfile/sources_test.go`** — 14 tests (built-ins, composition, dedup, cycles, overrides, parser integration, end-to-end checksum, includes merging, runner up-to-date).
- **Dogfood**: project's own `gogo.yaml` migrated to `sources: go` / `sources: lint` (63 → 53 lines, 4 copies of the glob block → 1 named preset).
- **Docs**: new "Presets" section in `sources-checksums`, top-level `sources:` row in `task-file-syntax`, README + quickstart + watch-mode + landing page examples switched to `sources: go`.