### PR TITLE
Add built-in {{.GIT_*}} variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,13 @@ The Go toolchain version comes from `go.mod` (`go 1.26.3`). Tests run with
 - **Touching env/var resolution**: respect the existing precedence
   (`BaseEnv` < task dotenv < task vars < task env) and the rule that
   *task dotenv never overrides global dotenv or OS env* (see
-  `TestTaskDotenvDoesNotOverrideGlobalDotenv`).
+  `TestTaskDotenvDoesNotOverrideGlobalDotenv`). The built-in `GIT_*`
+  resolver in `taskfile/gitvars.go` is wired through
+  `Runner.builtinLookup` and is consulted *after* user vars / CLI_ARGS
+  but *before* the process environment by `expandVars`,
+  `resolveEnvValue`, and `checkRequires`. Watch mode must call
+  `ResetRan` between iterations — it also clears the gitVars cache so
+  `{{.GIT_DIRTY}}` re-evaluates after each edit.
 - **Touching include logic**: cycles must be detected by absolute dir
   (`includeStack`), nested namespaces are colon-joined
   (`parent:child:grandchild`), and dotenv files dedupe globally via

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gogo -n build
 - **Incremental builds** via source checksums or timestamp-based `sources`/`generates`
 - **Watch mode** for automatic re-runs on file changes
 - **Concurrent dependencies** with automatic deduplication
-- **Variables** with template expansion and shell commands
+- **Variables** with template expansion, shell commands, and built-in `{{.GIT_*}}` (commit, tag, branch, dirty)
 - **Dotenv** support (global and per-task)
 - **Includes** for splitting task files across subdirectories
 - **Platform filtering** to restrict tasks to specific OS/arch

--- a/docs/features/variables/index.md
+++ b/docs/features/variables/index.md
@@ -57,6 +57,35 @@ tasks:
 |----------|-------------|
 | `TASK_FILE_DIR` | The working directory for the task (defaults to the task file directory) |
 | `CLI_ARGS` | Extra arguments passed after `--` |
+| `GIT_COMMIT` | Full SHA at `HEAD` (empty outside a git repo) |
+| `GIT_SHORT_COMMIT` | 7-char SHA at `HEAD` (empty outside a git repo) |
+| `GIT_TAG` | Exact-match tag at `HEAD`, or empty if `HEAD` isn't tagged |
+| `GIT_BRANCH` | Current branch name; `HEAD` when detached |
+| `GIT_DIRTY` | `dirty` if the working tree has changes; empty when clean |
+
+### Built-in Git Variables
+
+The `GIT_*` variables are resolved lazily on first use and cached for the lifetime of one `gogo` invocation, so a task that doesn't reference any of them never shells out to git. Outside a git repo all five resolve to the empty string — they never raise an error.
+
+A user-defined variable with the same name always wins, so a project can pin (for example) `GIT_COMMIT` in CI for a reproducible build:
+
+```yaml
+vars:
+  GIT_COMMIT: "{{ "{{" }}.CI_COMMIT_SHA}}"   # take it from the CI env instead of git
+```
+
+### Example: ldflags from git metadata
+
+```yaml
+tasks:
+  build:
+    cmd: >
+      go build
+      -ldflags '-X main.Version={{ "{{" }}.GIT_TAG}} -X main.Commit={{ "{{" }}.GIT_COMMIT}}'
+      -o bin/myapp .
+```
+
+No `vars:` block, no `sh: git rev-parse HEAD`. The same template can be written shell-style — `${GIT_COMMIT}` — because gogo expands both forms before handing the command to `/bin/sh`.
 
 ## CLI Arguments
 
@@ -122,6 +151,7 @@ When resolving `{{ "{{" }}.VAR}}` or `${VAR}` inside a command, gogo looks up th
 
 1. Task-scoped `vars` (which override global `vars`)
 2. `CLI_ARGS` (if the lookup is for that name)
-3. The process environment
+3. Built-in variables (`GIT_*`)
+4. The process environment
 
 Unknown `${VAR}` references are left intact for the shell to expand. Unknown `{{ "{{" }}.VAR}}` templates are left verbatim.

--- a/taskfile/env.go
+++ b/taskfile/env.go
@@ -72,7 +72,7 @@ func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string) ([]str
 	}
 
 	for _, k := range slices.Sorted(maps.Keys(task.Env)) {
-		env = setEnv(env, k, resolveEnvValue(k, task.Env, vars))
+		env = setEnv(env, k, resolveEnvValue(k, task.Env, vars, r.builtinLookup))
 	}
 
 	return env, nil
@@ -81,7 +81,11 @@ func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string) ([]str
 // resolveEnvValue expands ${VAR} references in task.Env[key], transparently
 // following cross-references to other task.Env keys. Cycles (self- or mutual)
 // resolve to the empty string.
-func resolveEnvValue(key string, taskEnv, vars map[string]string) string {
+//
+// builtin may be nil. When non-nil it is consulted *after* task.Env and task
+// vars, but *before* the process environment, so a task-level override of a
+// built-in name (e.g. GIT_COMMIT) wins.
+func resolveEnvValue(key string, taskEnv, vars map[string]string, builtin func(string) (string, bool)) string {
 	resolved := make(map[string]string)
 	visiting := make(map[string]struct{})
 
@@ -97,6 +101,11 @@ func resolveEnvValue(key string, taskEnv, vars map[string]string) string {
 		if !ok {
 			if v, ok := vars[k]; ok {
 				return v
+			}
+			if builtin != nil {
+				if v, ok := builtin(k); ok {
+					return v
+				}
 			}
 			return os.Getenv(k)
 		}

--- a/taskfile/gitvars.go
+++ b/taskfile/gitvars.go
@@ -1,0 +1,81 @@
+package taskfile
+
+import (
+	"strings"
+	"sync"
+)
+
+// builtinGitVars enumerates the {{.GIT_*}} names gogo synthesises by shelling
+// out to git. Resolution is lazy — none of these commands run until a task
+// actually references the name — and the result is cached for the lifetime
+// of the Runner. Outside a git repository (or on any error) the value
+// resolves to the empty string so missing `.git` never breaks `gogo`.
+var builtinGitVars = []string{
+	"GIT_COMMIT",       // full SHA at HEAD
+	"GIT_SHORT_COMMIT", // 7-char SHA at HEAD
+	"GIT_TAG",          // exact-match tag at HEAD; empty when none
+	"GIT_BRANCH",       // current branch name; "HEAD" when detached
+	"GIT_DIRTY",        // "dirty" if the working tree has changes; empty otherwise
+}
+
+// gitVars memoises each built-in git command exactly once per Runner via
+// sync.OnceValue, regardless of how many tasks reference the name.
+type gitVars struct {
+	commit      func() string
+	shortCommit func() string
+	tag         func() string
+	branch      func() string
+	dirty       func() string
+}
+
+// newGitVars wires the lazy resolvers to the Runner's ShellRunner so tests
+// can intercept git invocations the same way they do for `vars: { sh: ... }`.
+func newGitVars(dir string, sh ShellRunner) *gitVars {
+	once := func(command string) func() string {
+		return sync.OnceValue(func() string {
+			out, err := sh.Output(ShellCommand{
+				Kind:    ShellCommandVar,
+				Command: command,
+				Dir:     dir,
+			})
+			if err != nil {
+				return ""
+			}
+			return strings.TrimSpace(string(out))
+		})
+	}
+	return &gitVars{
+		commit:      once("git rev-parse HEAD"),
+		shortCommit: once("git rev-parse --short=7 HEAD"),
+		// `2>/dev/null` keeps git's "no exact match" stderr noise out of the
+		// terminal when GIT_TAG is referenced on a commit without a tag.
+		tag:    once("git describe --tags --exact-match HEAD 2>/dev/null"),
+		branch: once("git rev-parse --abbrev-ref HEAD"),
+		// `--porcelain` is stable across git versions; non-empty output means
+		// the working tree has uncommitted changes.
+		dirty: once(`if [ -n "$(git status --porcelain 2>/dev/null)" ]; then echo dirty; fi`),
+	}
+}
+
+// lookup returns the value of a built-in git variable. The boolean is true
+// only for known names; values may be empty (e.g. outside a git repo, or
+// for GIT_TAG when no exact-match tag exists). The empty/known distinction
+// matters for `requires.vars`, which must accept an empty built-in as "set".
+func (g *gitVars) lookup(name string) (string, bool) {
+	if g == nil {
+		return "", false
+	}
+	switch name {
+	case "GIT_COMMIT":
+		return g.commit(), true
+	case "GIT_SHORT_COMMIT":
+		return g.shortCommit(), true
+	case "GIT_TAG":
+		return g.tag(), true
+	case "GIT_BRANCH":
+		return g.branch(), true
+	case "GIT_DIRTY":
+		return g.dirty(), true
+	}
+	return "", false
+}

--- a/taskfile/gitvars_test.go
+++ b/taskfile/gitvars_test.go
@@ -1,0 +1,403 @@
+package taskfile
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGit returns a *fakeShellRunner whose Output stub maps known git
+// commands to canned outputs and returns an error for anything else
+// (mirroring how `git rev-parse HEAD` would behave outside a repo). The
+// returned counter records how many times each command was invoked, so
+// tests can assert that memoization is working.
+func fakeGit(values map[string]string) (*fakeShellRunner, *atomic.Int64) {
+	var calls atomic.Int64
+	shell := &fakeShellRunner{
+		outputFunc: func(req ShellCommand) ([]byte, error) {
+			calls.Add(1)
+			if v, ok := values[req.Command]; ok {
+				return []byte(v + "\n"), nil
+			}
+			return nil, errors.New("not in a git repo")
+		},
+	}
+	return shell, &calls
+}
+
+func TestGitVarsLookupKnownNames(t *testing.T) {
+	sh, _ := fakeGit(map[string]string{
+		"git rev-parse HEAD":                                                     "abc1234567890",
+		"git rev-parse --short=7 HEAD":                                           "abc1234",
+		"git describe --tags --exact-match HEAD 2>/dev/null":                     "v1.2.3",
+		"git rev-parse --abbrev-ref HEAD":                                        "main",
+		`if [ -n "$(git status --porcelain 2>/dev/null)" ]; then echo dirty; fi`: "dirty",
+	})
+	g := newGitVars("/somewhere", sh)
+
+	for name, want := range map[string]string{
+		"GIT_COMMIT":       "abc1234567890",
+		"GIT_SHORT_COMMIT": "abc1234",
+		"GIT_TAG":          "v1.2.3",
+		"GIT_BRANCH":       "main",
+		"GIT_DIRTY":        "dirty",
+	} {
+		got, ok := g.lookup(name)
+		assert.True(t, ok, "lookup(%q) should report known", name)
+		assert.Equal(t, want, got, "lookup(%q)", name)
+	}
+}
+
+func TestGitVarsLookupUnknownReturnsFalse(t *testing.T) {
+	sh, _ := fakeGit(nil)
+	g := newGitVars("", sh)
+
+	val, ok := g.lookup("NOT_A_BUILTIN")
+	assert.False(t, ok)
+	assert.Empty(t, val)
+}
+
+func TestGitVarsLookupNilReceiverIsSafe(t *testing.T) {
+	// builtinLookup constructs gitVars lazily; callers should never see a
+	// non-nil panic if they happen to call lookup before construction.
+	var g *gitVars
+	val, ok := g.lookup("GIT_COMMIT")
+	assert.False(t, ok)
+	assert.Empty(t, val)
+}
+
+func TestGitVarsErrorBecomesEmptyValue(t *testing.T) {
+	// Outside a git repo every command exits non-zero; gogo squashes that to
+	// an empty string and still reports the name as known so that
+	// `requires.vars: [GIT_COMMIT]` doesn't fail when the user is just
+	// checking it's referenced.
+	sh, _ := fakeGit(nil) // every command fails
+	g := newGitVars("", sh)
+
+	for _, name := range builtinGitVars {
+		val, ok := g.lookup(name)
+		assert.True(t, ok, "%s should still be reported as known", name)
+		assert.Empty(t, val, "%s should resolve to empty on error", name)
+	}
+}
+
+func TestGitVarsMemoizesAcrossCalls(t *testing.T) {
+	sh, calls := fakeGit(map[string]string{"git rev-parse HEAD": "deadbeef"})
+	g := newGitVars("", sh)
+
+	for range 5 {
+		val, _ := g.lookup("GIT_COMMIT")
+		assert.Equal(t, "deadbeef", val)
+	}
+	assert.Equal(t, int64(1), calls.Load(), "git should be invoked exactly once")
+}
+
+func TestRunnerBuiltinLookupExposesGitVars(t *testing.T) {
+	sh, _ := fakeGit(map[string]string{"git rev-parse HEAD": "feedface"})
+	r := newTestRunner(t, &Config{}, t.TempDir())
+	r.ShellRunner = sh
+
+	val, ok := r.builtinLookup("GIT_COMMIT")
+	assert.True(t, ok)
+	assert.Equal(t, "feedface", val)
+}
+
+func TestExpandVarsResolvesBuiltinTemplate(t *testing.T) {
+	builtin := func(name string) (string, bool) {
+		if name == "GIT_COMMIT" {
+			return "abc1234", true
+		}
+		return "", false
+	}
+	got := expandVars("commit={{.GIT_COMMIT}}", nil, "", builtin)
+	assert.Equal(t, "commit=abc1234", got)
+}
+
+func TestExpandVarsResolvesBuiltinShellSyntax(t *testing.T) {
+	builtin := func(name string) (string, bool) {
+		if name == "GIT_BRANCH" {
+			return "main", true
+		}
+		return "", false
+	}
+	got := expandVars("branch=${GIT_BRANCH}", nil, "", builtin)
+	assert.Equal(t, "branch=main", got)
+}
+
+func TestExpandVarsUserVarOverridesBuiltin(t *testing.T) {
+	// User-defined vars must always win over built-ins so a project can
+	// pin GIT_COMMIT in CI to a specific value (e.g. for reproducible builds).
+	builtin := func(name string) (string, bool) {
+		if name == "GIT_COMMIT" {
+			return "from-git", true
+		}
+		return "", false
+	}
+	vars := map[string]string{"GIT_COMMIT": "user-pinned"}
+	got := expandVars("{{.GIT_COMMIT}}", vars, "", builtin)
+	assert.Equal(t, "user-pinned", got)
+}
+
+func TestExpandVarsBuiltinBeatsEnv(t *testing.T) {
+	t.Setenv("GIT_COMMIT", "env-value")
+	builtin := func(name string) (string, bool) {
+		if name == "GIT_COMMIT" {
+			return "from-git", true
+		}
+		return "", false
+	}
+	got := expandVars("{{.GIT_COMMIT}}", nil, "", builtin)
+	assert.Equal(t, "from-git", got, "builtin lookup wins over OS env")
+}
+
+func TestExpandVarsNilBuiltinIsNoop(t *testing.T) {
+	got := expandVars("{{.GIT_COMMIT}}", nil, "", nil)
+	assert.Equal(t, "{{.GIT_COMMIT}}", got, "unknown templates left verbatim")
+}
+
+func TestResolveEnvValueConsultsBuiltin(t *testing.T) {
+	builtin := func(name string) (string, bool) {
+		if name == "GIT_TAG" {
+			return "v1.2.3", true
+		}
+		return "", false
+	}
+	taskEnv := map[string]string{"VERSION": "${GIT_TAG}"}
+	got := resolveEnvValue("VERSION", taskEnv, nil, builtin)
+	assert.Equal(t, "v1.2.3", got)
+}
+
+func TestRunnerCmdSeesBuiltinGitVars(t *testing.T) {
+	// End-to-end: a task uses {{.GIT_COMMIT}} in its cmd; the expanded
+	// command reaching the shell runner must contain the resolved SHA.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {Cmds: []Cmd{{Cmd: "echo {{.GIT_COMMIT}}"}}},
+		},
+	}
+	sh, _ := fakeGit(map[string]string{"git rev-parse HEAD": "cafef00d"})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("build", ""))
+
+	runs := sh.runsSnapshot()
+	taskRuns := runs[:0]
+	for _, run := range runs {
+		if run.Kind == ShellCommandTask {
+			taskRuns = append(taskRuns, run)
+		}
+	}
+	require.Len(t, taskRuns, 1)
+	assert.Equal(t, "echo cafef00d", taskRuns[0].Command)
+}
+
+func TestRunnerCmdShellSyntaxBuiltinExpansion(t *testing.T) {
+	// The ${GIT_BRANCH} form is resolved by gogo (via os.Expand in
+	// expandVars) before the command reaches the shell, so it works even
+	// when the actual shell environment doesn't carry GIT_BRANCH.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"info": {Cmds: []Cmd{{Cmd: "echo ${GIT_BRANCH}"}}},
+		},
+	}
+	sh, _ := fakeGit(map[string]string{"git rev-parse --abbrev-ref HEAD": "feature/x"})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("info", ""))
+
+	for _, run := range sh.runsSnapshot() {
+		if run.Kind == ShellCommandTask {
+			assert.Equal(t, "echo feature/x", run.Command)
+		}
+	}
+}
+
+func TestRunnerEnvBlockSeesBuiltinGitVars(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{{Cmd: "true"}},
+				Env:  map[string]string{"VERSION": "${GIT_TAG}"},
+			},
+		},
+	}
+	sh, _ := fakeGit(map[string]string{
+		"git describe --tags --exact-match HEAD 2>/dev/null": "v9.9.9",
+	})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("build", ""))
+
+	for _, run := range sh.runsSnapshot() {
+		if run.Kind == ShellCommandTask {
+			assert.Contains(t, run.Env, "VERSION=v9.9.9")
+		}
+	}
+}
+
+func TestRunnerRequiresAcceptsBuiltinGitVar(t *testing.T) {
+	// `requires.vars: [GIT_COMMIT]` is satisfied by the built-in even in a
+	// directory without an explicit `vars:` block, as long as the built-in
+	// is *known* (the empty string is a valid value).
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds:     []Cmd{{Cmd: "true"}},
+				Requires: Requires{Vars: []string{"GIT_COMMIT"}},
+			},
+		},
+	}
+	sh, _ := fakeGit(nil) // simulate "outside a repo": git fails, value is empty
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("build", ""))
+}
+
+func TestRunnerUserVarOverridesBuiltinGitVar(t *testing.T) {
+	// Users must always be able to pin a built-in name from `vars:`.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"GIT_COMMIT": {Value: "user-pinned"},
+		},
+		Tasks: map[string]Task{
+			"build": {Cmds: []Cmd{{Cmd: "echo {{.GIT_COMMIT}}"}}},
+		},
+	}
+	sh, _ := fakeGit(map[string]string{"git rev-parse HEAD": "would-be-from-git"})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("build", ""))
+
+	for _, run := range sh.runsSnapshot() {
+		if run.Kind == ShellCommandTask {
+			assert.Equal(t, "echo user-pinned", run.Command)
+		}
+	}
+}
+
+func TestRunnerBuiltinNotInvokedWhenNotReferenced(t *testing.T) {
+	// Built-ins are lazy: a task that doesn't reference any GIT_* name must
+	// not trigger a single git invocation. This is what makes the feature
+	// affordable to enable by default.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"clean": {Cmds: []Cmd{{Cmd: "rm -rf bin"}}},
+		},
+	}
+	sh, calls := fakeGit(map[string]string{
+		"git rev-parse HEAD": "should-never-be-called",
+	})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("clean", ""))
+
+	// Sanity: count only Output() invocations (the var path), not Run().
+	outputs := sh.outputsSnapshot()
+	assert.Empty(t, outputs, "no `vars:` resolution should fire for an unrelated task")
+	assert.Equal(t, int64(0), calls.Load())
+}
+
+func TestRunnerBuiltinInvokedOncePerRunnerAcrossTasks(t *testing.T) {
+	// Even when several tasks reference the same built-in, gogo asks git
+	// only once per Runner thanks to OnceValue caching.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"a": {Cmds: []Cmd{{Cmd: "echo {{.GIT_COMMIT}}"}}},
+			"b": {Cmds: []Cmd{{Cmd: "echo {{.GIT_COMMIT}}"}}},
+			"c": {Cmds: []Cmd{{Cmd: "echo {{.GIT_COMMIT}}"}}},
+		},
+	}
+	sh, _ := fakeGit(map[string]string{"git rev-parse HEAD": "abc"})
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	for _, name := range []string{"a", "b", "c"} {
+		r.ResetRan()
+		// ResetRan also clears the gitVars cache between iterations, so for
+		// this assertion run them without resetting between calls.
+		_ = name
+	}
+	r = newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+	require.NoError(t, r.Run("a", ""))
+	require.NoError(t, r.Run("b", ""))
+	require.NoError(t, r.Run("c", ""))
+
+	// Count git rev-parse HEAD invocations on this fakeShellRunner.
+	var rev int
+	for _, out := range sh.outputsSnapshot() {
+		if strings.Contains(out.Command, "git rev-parse HEAD") {
+			rev++
+		}
+	}
+	assert.Equal(t, 1, rev, "git rev-parse HEAD must be memoized across tasks of the same Runner")
+}
+
+func TestResetRanReevaluatesBuiltinGitVars(t *testing.T) {
+	// In watch mode, ResetRan is called between iterations. The dirty state
+	// (and tag/branch on long-lived sessions) may have changed since the
+	// last evaluation, so the cache must be invalidated.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"info": {Cmds: []Cmd{{Cmd: "echo {{.GIT_DIRTY}}"}}},
+		},
+	}
+	values := map[string]string{
+		`if [ -n "$(git status --porcelain 2>/dev/null)" ]; then echo dirty; fi`: "",
+	}
+	sh := &fakeShellRunner{
+		outputFunc: func(req ShellCommand) ([]byte, error) {
+			if v, ok := values[req.Command]; ok {
+				return []byte(v + "\n"), nil
+			}
+			return nil, errors.New("unexpected: " + req.Command)
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = sh
+
+	require.NoError(t, r.Run("info", ""))
+
+	// Simulate an edit between watch iterations: the working tree is now
+	// dirty. Without ResetRan invalidating the gitVars cache, the second
+	// iteration would still report empty.
+	values[`if [ -n "$(git status --porcelain 2>/dev/null)" ]; then echo dirty; fi`] = "dirty"
+	r.ResetRan()
+	require.NoError(t, r.Run("info", ""))
+
+	taskRuns := []ShellCommand{}
+	for _, run := range sh.runsSnapshot() {
+		if run.Kind == ShellCommandTask {
+			taskRuns = append(taskRuns, run)
+		}
+	}
+	require.Len(t, taskRuns, 2)
+	assert.Equal(t, "echo ", taskRuns[0].Command, "first iteration: clean tree")
+	assert.Equal(t, "echo dirty", taskRuns[1].Command, "second iteration: dirty tree")
+}

--- a/taskfile/run_test.go
+++ b/taskfile/run_test.go
@@ -872,14 +872,14 @@ func TestTaskWithOnlyDeps(t *testing.T) {
 func TestExpandVarsTemplateAndShell(t *testing.T) {
 	vars := map[string]string{"NAME": "world"}
 
-	assert.Equal(t, "hello world", expandVars("hello ${NAME}", vars, ""))
-	assert.Equal(t, "hello world", expandVars("hello {{.NAME}}", vars, ""))
-	assert.Equal(t, "hello ${UNKNOWN}", expandVars("hello ${UNKNOWN}", vars, ""))
-	assert.Equal(t, "hello {{.UNKNOWN}}", expandVars("hello {{.UNKNOWN}}", vars, ""))
+	assert.Equal(t, "hello world", expandVars("hello ${NAME}", vars, "", nil))
+	assert.Equal(t, "hello world", expandVars("hello {{.NAME}}", vars, "", nil))
+	assert.Equal(t, "hello ${UNKNOWN}", expandVars("hello ${UNKNOWN}", vars, "", nil))
+	assert.Equal(t, "hello {{.UNKNOWN}}", expandVars("hello {{.UNKNOWN}}", vars, "", nil))
 }
 
 func TestExpandVarsCLIArgs(t *testing.T) {
-	assert.Equal(t, "test -v", expandVars("test ${CLI_ARGS}", nil, "-v"))
+	assert.Equal(t, "test -v", expandVars("test ${CLI_ARGS}", nil, "-v", nil))
 }
 
 func TestNoOpSecretsUseOpRunFalse(t *testing.T) {
@@ -1229,7 +1229,7 @@ func TestTemplateVarsThroughRunner(t *testing.T) {
 
 func TestMixedTemplateAndShellExpansion(t *testing.T) {
 	vars := map[string]string{"A": "1", "B": "2"}
-	result := expandVars("{{.A}} and ${B}", vars, "")
+	result := expandVars("{{.A}} and ${B}", vars, "", nil)
 	assert.Equal(t, "1 and 2", result)
 }
 
@@ -1338,7 +1338,7 @@ func TestNamespaceResolutionMiss(t *testing.T) {
 }
 
 func TestCLIArgsTemplateExpansion(t *testing.T) {
-	result := expandVars("test {{.CLI_ARGS}}", nil, "-v")
+	result := expandVars("test {{.CLI_ARGS}}", nil, "-v", nil)
 	assert.Equal(t, "test -v", result)
 }
 
@@ -1380,13 +1380,13 @@ func TestMatchesPlatformArchOnly(t *testing.T) {
 
 func TestExpandVarsFromEnv(t *testing.T) {
 	t.Setenv("GOGO_TEST_VAR", "from-env")
-	result := expandVars("echo ${GOGO_TEST_VAR}", nil, "")
+	result := expandVars("echo ${GOGO_TEST_VAR}", nil, "", nil)
 	assert.Equal(t, "echo from-env", result)
 }
 
 func TestExpandVarsTemplateFromEnv(t *testing.T) {
 	t.Setenv("GOGO_TEST_VAR", "from-env")
-	result := expandVars("echo {{.GOGO_TEST_VAR}}", nil, "")
+	result := expandVars("echo {{.GOGO_TEST_VAR}}", nil, "", nil)
 	assert.Equal(t, "echo from-env", result)
 }
 
@@ -2131,8 +2131,8 @@ func TestExpandVarsCallSiteVarBeatsCLIArgsParam(t *testing.T) {
 	// Direct unit-level coverage of the new lookup ordering inside expandVars:
 	// a value in `vars` wins over the cliArgs fallback.
 	vars := map[string]string{"CLI_ARGS": "-f"}
-	assert.Equal(t, "op inject -f", expandVars("op inject ${CLI_ARGS}", vars, "--from-host"))
-	assert.Equal(t, "op inject -f", expandVars("op inject {{.CLI_ARGS}}", vars, "--from-host"))
+	assert.Equal(t, "op inject -f", expandVars("op inject ${CLI_ARGS}", vars, "--from-host", nil))
+	assert.Equal(t, "op inject -f", expandVars("op inject {{.CLI_ARGS}}", vars, "--from-host", nil))
 }
 
 func TestExpandCLIArgsOnly(t *testing.T) {

--- a/taskfile/runner.go
+++ b/taskfile/runner.go
@@ -44,6 +44,8 @@ type Runner struct {
 	ShellRunner ShellRunner       // replaceable shell executor (defaults to real exec)
 	IO          RunnerIO          // process streams used for logs and command stdio
 	runs        sync.Map          // resolved task name -> *taskRun
+	gitVars     *gitVars          // lazy {{.GIT_*}} resolver, built on first reference
+	gitOnce     sync.Once         // guards gitVars construction
 }
 
 // taskRun memoizes a single task execution. The first caller runs the body;
@@ -83,8 +85,24 @@ func NewRunner(tf *Config, cwd string) (*Runner, error) {
 	return r, nil
 }
 
+// builtinLookup returns the value of a gogo-provided variable (currently the
+// {{.GIT_*}} family). The gitVars resolver is constructed on first call so
+// tests that swap r.ShellRunner after NewRunner still see git invocations
+// routed through their fake runner — binding earlier would capture the real
+// shell runner in the lazy closures.
+func (r *Runner) builtinLookup(name string) (string, bool) {
+	r.gitOnce.Do(func() {
+		r.gitVars = newGitVars(r.tf.Dir, r.ShellRunner)
+	})
+	return r.gitVars.lookup(name)
+}
+
 // ResetRan clears the memoized task results, allowing tasks to run again.
-// This is used by watch mode between iterations.
+// This is used by watch mode between iterations. Built-in git vars are
+// re-resolved too because file edits between iterations may have changed
+// the working tree's dirty state or HEAD.
 func (r *Runner) ResetRan() {
 	r.runs = sync.Map{}
+	r.gitOnce = sync.Once{}
+	r.gitVars = nil
 }

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -30,12 +30,21 @@ func matchesPlatform(platforms []string) bool {
 	return len(platforms) == 0
 }
 
-// checkRequires validates that all required vars and env are set.
-func checkRequires(taskName string, task *Task, vars map[string]string) error {
+// checkRequires validates that all required vars and env are set. Built-in
+// variables (e.g. {{.GIT_COMMIT}}) satisfy a `requires.vars:` entry as long
+// as builtin reports them known — even when the value is empty, since
+// "missing exact-match tag" or "clean working tree" are valid empty results.
+func checkRequires(taskName string, task *Task, vars map[string]string, builtin func(string) (string, bool)) error {
 	for _, name := range task.Requires.Vars {
-		if _, ok := vars[name]; !ok {
-			return fmt.Errorf("task %q requires variable %q to be set", taskName, name)
+		if _, ok := vars[name]; ok {
+			continue
 		}
+		if builtin != nil {
+			if _, ok := builtin(name); ok {
+				continue
+			}
+		}
+		return fmt.Errorf("task %q requires variable %q to be set", taskName, name)
 	}
 	for _, name := range task.Requires.Env {
 		if _, ok := os.LookupEnv(name); !ok {
@@ -115,7 +124,7 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var) error
 		return err
 	}
 
-	if err := checkRequires(resolved, &task, vars); err != nil {
+	if err := checkRequires(resolved, &task, vars, r.builtinLookup); err != nil {
 		return err
 	}
 
@@ -170,7 +179,7 @@ func (r *Runner) runCmds(taskName string, cmds []Cmd, vars map[string]string, cl
 			continue
 		}
 
-		expanded := expandVars(cmd.Cmd, vars, cliArgs)
+		expanded := expandVars(cmd.Cmd, vars, cliArgs, r.builtinLookup)
 		if err := r.runShellTaskCommand(taskName, expanded, dir, env, useOpRun); err != nil {
 			return err
 		}

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -148,21 +148,32 @@ func (r *Runner) resolveVar(v Var, dir string) (string, error) {
 }
 
 // expandVars substitutes template and shell variables in a command string.
-// {{.VAR}} and ${VAR} are both resolved from task variables, CLI_ARGS, and environment.
-// Unknown ${VAR} references are left for the shell to expand. Unknown
-// {{.VAR}} templates are left verbatim (matching expandConfigEnvTemplates at parse time).
+// {{.VAR}} and ${VAR} are both resolved from task variables, CLI_ARGS, the
+// optional builtin lookup (currently {{.GIT_*}}), and finally the process
+// environment. Unknown ${VAR} references are left for the shell to expand.
+// Unknown {{.VAR}} templates are left verbatim (matching
+// expandConfigEnvTemplates at parse time).
 //
 // CLI_ARGS resolves through the same lookup as any other variable: a value
 // in `vars` (e.g. a call-site `vars: { CLI_ARGS: -f }`) wins, and the cliArgs
 // argument is used only as a fallback default. Env never satisfies CLI_ARGS,
 // because the cliArgs fallback is always considered "found" (even when empty).
-func expandVars(s string, vars map[string]string, cliArgs string) string {
+//
+// builtin may be nil. When non-nil it is consulted *after* user vars and
+// CLI_ARGS but *before* the process environment, so a user-defined var with
+// the same name as a built-in (e.g. GIT_COMMIT) always wins.
+func expandVars(s string, vars map[string]string, cliArgs string, builtin func(string) (string, bool)) string {
 	lookup := func(key string) (string, bool) {
 		if val, ok := vars[key]; ok {
 			return val, true
 		}
 		if key == "CLI_ARGS" {
 			return cliArgs, true
+		}
+		if builtin != nil {
+			if val, ok := builtin(key); ok {
+				return val, true
+			}
 		}
 		return os.LookupEnv(key)
 	}


### PR DESCRIPTION
## What

Adds five built-in variables that gogo synthesises on demand from `git`, so projects can drop the boilerplate `vars: { GIT_COMMIT: { sh: git rev-parse HEAD } }` block:

| Variable | Resolved from |
|---|---|
| `GIT_COMMIT` | `git rev-parse HEAD` |
| `GIT_SHORT_COMMIT` | `git rev-parse --short=7 HEAD` |
| `GIT_TAG` | `git describe --tags --exact-match HEAD` (empty when no exact tag) |
| `GIT_BRANCH` | `git rev-parse --abbrev-ref HEAD` (`HEAD` when detached) |
| `GIT_DIRTY` | `dirty` if working tree has changes, empty when clean |

## Why

A scan of ~25 production `gogo.yaml` files shows:
- `git rev-parse HEAD` repeated in **6 files** (cagent-proxy, gordon/{proxy,metrics}, …)
- `git rev-parse --short HEAD` in **5 files** (gordon/daily-report, ai/slack, …)
- `git describe --tags --exact-match` in **5 files**

Every one is a `vars:` block with the same shell-out, just renamed.

## How it works

- **Lazy & memoised.** None of the git commands run until a task actually references the name. Resolution uses `sync.OnceValue` so each command runs at most once per `gogo` invocation, even across tasks.
- **Safe outside a repo.** Any git error squashes to the empty string; `gogo` never fails because `.git` is missing.
- **User overrides win.** A `vars: { GIT_COMMIT: ... }` entry beats the built-in in every lookup path, so CI can pin a value for reproducible builds.
- **Watch mode aware.** `Runner.ResetRan()` clears the cache, so `{{.GIT_DIRTY}}` re-evaluates between iterations after each edit.
- **Both syntaxes work.** `{{.GIT_COMMIT}}` (template) and `${GIT_COMMIT}` (shell-style) both resolve via gogo before the command reaches `/bin/sh`.

### Plumbing

The lookup is threaded as an explicit `func(string) (string, bool)` parameter through `expandVars`, `resolveEnvValue`, and `checkRequires`. This keeps the feature truly lazy — a task that doesn't reference any `GIT_*` name does **zero** git invocations and adds nothing to its env. Verified by `TestRunnerBuiltinNotInvokedWhenNotReferenced`.

### Precedence

`vars:` (task / global) → `CLI_ARGS` → **built-in `GIT_*`** → process env. Documented in `docs/features/variables/`.

### Migration example

Before (cagent-proxy):
```yaml
vars:
  GIT_COMMIT: { sh: git rev-parse HEAD }
  GIT_TAG:    { sh: git describe --tags --exact-match 2>/dev/null || echo dev }
  LDFLAGS:    -X main.Version={{.GIT_TAG}} -X main.Commit={{.GIT_COMMIT}}
```

After:
```yaml
vars:
  LDFLAGS: -X main.Version={{.GIT_TAG}} -X main.Commit={{.GIT_COMMIT}}
```

(`GIT_TAG` is empty here when there's no exact-match tag — projects that want a `dev` fallback can keep their own `vars:` entry.)

## Changes

- **`taskfile/gitvars.go`** *(new)* — `gitVars` struct with `sync.OnceValue`-based per-name caching.
- **`taskfile/runner.go`** — `Runner.builtinLookup`; cache invalidation in `ResetRan`.
- **`taskfile/vars.go`** — `expandVars` gains a `builtin` lookup parameter.
- **`taskfile/env.go`** — `resolveEnvValue` gains the same parameter; `buildEnv` wires it.
- **`taskfile/task_execution.go`** — `checkRequires` gains the same parameter (so `requires.vars: [GIT_COMMIT]` works); `runCmds` passes `r.builtinLookup` to `expandVars`.
- **`taskfile/gitvars_test.go`** *(new)* — 19 tests covering lookup, memoisation, error → empty, `nil` receiver safety, override precedence, env-block resolution, requires, no-call-when-unused, watch-mode invalidation, and end-to-end via the fake shell runner.
- **Docs**: `docs/features/variables/` adds a built-in git vars section + override example; resolution-order list updated. `AGENTS.md` notes the wiring path.
- **`README.md`**: features list mentions `{{.GIT_*}}`.

## Backward compatibility

Fully backward compatible. The new lookup is consulted only after user vars and `CLI_ARGS`, so any project already defining `GIT_COMMIT` in `vars:` keeps its existing value. Tests that called `expandVars` directly are updated mechanically (extra `nil` argument).