### PR TITLE
Top-level default: field + parent->child env propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,16 @@ The Go toolchain version comes from `go.mod` (`go 1.26.3`). Tests run with
   `taskfile.Config` test in `run_test.go` plus a `Parse`-based test in
   `parse_test.go` if YAML shape matters.
 - **Touching env/var resolution**: respect the existing precedence
-  (`BaseEnv` < task dotenv < task vars < task env) and the rule that
-  *task dotenv never overrides global dotenv or OS env* (see
-  `TestTaskDotenvDoesNotOverrideGlobalDotenv`). The built-in `GIT_*`
-  resolver in `taskfile/gitvars.go` is wired through
+- **Touching env/var resolution**: respect the existing precedence
+  (`BaseEnv` < parent task env < task dotenv < task vars < task env) and the
+  rule that *task dotenv never overrides global dotenv or OS env* (see
+  `TestTaskDotenvDoesNotOverrideGlobalDotenv`). Sub-task calls
+  (`cmds: - task: X`) propagate the parent's resolved env via
+  `Runner.runSubTask` — deps do NOT (they're prerequisites, not sequenced
+  sub-calls; see `TestDepsDoNotInheritParentEnv`). Memoization is bypassed
+  whenever extraVars or parentEnv is non-nil so two call sites with
+  different context don't collapse into one execution. The built-in
+  `GIT_*` resolver in `taskfile/gitvars.go` is wired through
   `Runner.builtinLookup` and is consulted *after* user vars / CLI_ARGS
   but *before* the process environment by `expandVars`,
   `resolveEnvValue`, and `checkRequires`. Watch mode must call

--- a/app_test.go
+++ b/app_test.go
@@ -196,3 +196,53 @@ func TestAppPropagatesGetwdError(t *testing.T) {
 	err := app.Run(t.Context())
 	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
+
+func TestDefaultTaskNameUsesTopLevelDefault(t *testing.T) {
+	tf := &taskfile.Config{Default: "build"}
+	assert.Equal(t, "build", defaultTaskName("default", tf))
+
+	// An explicit positional arg always wins over the top-level field, so
+	// `gogo test` still runs `test` even when default: build is declared.
+	assert.Equal(t, "test", defaultTaskName("test", tf))
+}
+
+func TestDefaultTaskNameFallbackWhenUnset(t *testing.T) {
+	// Backward compatibility: with no top-level default the implicit
+	// "task literally named default" convention still works.
+	tf := &taskfile.Config{}
+	assert.Equal(t, "default", defaultTaskName("default", tf))
+}
+
+func TestAppRunsTopLevelDefaultTask(t *testing.T) {
+	// End-to-end: `gogo` (no positional arg) runs the task named by the
+	// top-level `default:` field instead of falling back to the implicit
+	// `default` task. --dry prints the cmd without executing it.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+default: dev
+tasks:
+  dev:
+    cmd: echo running-dev
+`)
+
+	app, _, stderr := newTestApp(t, dir, "--dry")
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "echo running-dev")
+}
+
+func TestAppRejectsUnknownDefault(t *testing.T) {
+	// A top-level `default:` that names a non-existent task fails fast at
+	// load time — the user gets a clear error rather than "task not found".
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+default: missing
+tasks:
+  build:
+    cmd: true
+`)
+
+	app, _, _ := newTestApp(t, dir)
+	err := app.Run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"missing"`)
+}

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -11,6 +11,7 @@ gogo reads task definitions from a `gogo.yaml` file in the current directory.
 | Field | Type | Description |
 |-------|------|-------------|
 | `version` | string | Optional version identifier |
+| `default` | string | Task to run when none is given on the CLI — replaces the convention of declaring a `default` task. Must reference a defined (possibly namespaced) task |
 | `includes` | list of strings | Subdirectories containing other task files (namespaced — see [Includes](../includes/)) |
 | `flatten` | list of strings | YAML files whose tasks merge into the current namespace without a prefix (see [Includes](../includes/#flatten)) |
 | `dotenv` | list of strings | Paths to `.env` files to load |
@@ -40,6 +41,45 @@ Each task supports the following fields:
 | `preconditions` | list | Shell commands that must succeed before the task runs |
 | `silent` | bool | When `true`, suppress the `[task] cmd` log line for each command |
 
+## Default Task
+
+A top-level `default:` field names the task that runs when no task is given on the command line:
+
+```yaml
+default: dev
+
+tasks:
+  dev:
+    deps: [build, test]
+  build:
+    cmd: go build ./...
+  test:
+    cmd: go test ./...
+```
+
+```sh
+gogo            # runs `dev`
+gogo build      # explicit task still wins over `default:`
+```
+
+If `default:` is unset, gogo falls back to running a task literally named `default` (the original convention). The two forms are interchangeable; `default:` simply removes the no-op trampoline:
+
+```yaml
+# Before — trampoline
+tasks:
+  default:
+    cmds:
+      - task: dev
+  dev: { cmd: ... }
+
+# After — top-level field
+default: dev
+tasks:
+  dev: { cmd: ... }
+```
+
+A `default:` that names a non-existent task is rejected at load time.
+
 ## Commands
 
 A command can be a simple string:
@@ -60,15 +100,20 @@ tasks:
       - golangci-lint run
 ```
 
-A command can also reference another task:
+A command can also reference another task. The sub-task **inherits the calling task's environment** (its `vars`, dotenv, and `env` block), so a parent's environment flows down without having to re-export it:
 
 ```yaml
 tasks:
-  all:
+  smoke:
+    env:
+      TESTSET_SIZE: "2"
+      MIRROR_FS: "1"
     cmds:
-      - task: build
-      - task: test
+      - task: gen      # both children see TESTSET_SIZE and MIRROR_FS
+      - task: ingest
 ```
+
+The child's own `env` block (or a per-call `vars:` override) wins per key. See [Variables](../variables/#parent-to-child-env-propagation) for the full precedence rules.
 
 ## Task Descriptions
 

--- a/docs/features/variables/index.md
+++ b/docs/features/variables/index.md
@@ -143,7 +143,39 @@ tasks:
     cmd: server --addr $ADDR
 ```
 
-Lookup order for `${VAR}` inside an env value: another key in the same `env` block first, then task `vars`, then the process environment. Self-cycles or mutual cycles between env keys resolve to the empty string rather than looping forever.
+Lookup order for `${VAR}` inside an env value: another key in the same `env` block first, then task `vars`, then **inherited parent env (when invoked via `cmds: - task: X`)**, then the process environment. Self-cycles or mutual cycles between env keys resolve to the empty string rather than looping forever.
+
+## Parent-to-child Env Propagation
+
+When a task calls another via `cmds: - task: X`, the child inherits the parent's resolved environment — vars, dotenv, and the parent's own `env:` block all flow down. This matches shell-function semantics and makes parent-driven workflows pleasant:
+
+```yaml
+tasks:
+  smoke:
+    env:
+      TESTSET_SIZE: "2"
+      MIRROR_FS: "1"
+    cmds:
+      - task: gen      # sees TESTSET_SIZE and MIRROR_FS
+      - task: ingest   # same
+```
+
+The child's own declarations override the inherited ones on a per-key basis:
+
+```yaml
+tasks:
+  parent:
+    env: { MODE: parent, SHARED: from-parent }
+    cmds:
+      - task: child
+  child:
+    env: { MODE: child }              # wins for MODE
+    cmd: echo $MODE / $SHARED         # prints: child / from-parent
+```
+
+**Deps don't inherit.** Tasks listed in `deps:` run as prerequisites before the parent's body and do *not* see the parent's `env:` block. Only `cmds: - task: X` invocations trigger propagation.
+
+When the same child is called by two different parents (or twice by the same parent with different env), each call site is a distinct execution — gogo bypasses its task-level memoization so the child re-runs with each set of inherited values.
 
 ## Variable Resolution Order
 

--- a/main.go
+++ b/main.go
@@ -94,6 +94,8 @@ func (a *App) Run(ctx context.Context) error {
 	runner.DryRun = parsed.DryRun
 	runner.Force = parsed.Force
 
+	taskName := defaultTaskName(parsed.Task, tf)
+
 	if parsed.Watch {
 		sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 		defer stop()
@@ -103,14 +105,25 @@ func (a *App) Run(ctx context.Context) error {
 			return err
 		}
 
-		err = runner.Watch(sigCtx, parsed.Task, cliArgs, interval)
+		err = runner.Watch(sigCtx, taskName, cliArgs, interval)
 		if err != nil && sigCtx.Err() != nil {
 			return nil // graceful shutdown
 		}
 		return err
 	}
 
-	return runner.Run(parsed.Task, cliArgs)
+	return runner.Run(taskName, cliArgs)
+}
+
+// defaultTaskName picks the task to run when the CLI position arg is the
+// arg-parser default ("default"). A top-level `default:` field in the task
+// file wins over the implicit "task literally named default" convention,
+// which lets users skip the `default:` trampoline entirely.
+func defaultTaskName(parsed string, tf *taskfile.Config) string {
+	if parsed == "default" && tf.Default != "" {
+		return tf.Default
+	}
+	return parsed
 }
 
 // shellJoin quotes each CLI argument so it survives splicing into a

--- a/taskfile/dotenv_test.go
+++ b/taskfile/dotenv_test.go
@@ -115,7 +115,7 @@ func TestBuildEnvWithTaskDotenv(t *testing.T) {
 	require.NoError(t, err)
 
 	task := &Task{Dotenv: []string{".env.task"}}
-	env, err := r.buildEnv(task, dir, nil)
+	env, err := r.buildEnv(task, dir, nil, nil)
 	require.NoError(t, err)
 	assert.Contains(t, env, "TASK_VAR=task_value")
 }
@@ -126,7 +126,7 @@ func TestBuildEnvWithoutTaskDotenv(t *testing.T) {
 	require.NoError(t, err)
 
 	task := &Task{}
-	env, err := r.buildEnv(task, tf.Dir, nil)
+	env, err := r.buildEnv(task, tf.Dir, nil, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, env) // at least inherited env vars
 }

--- a/taskfile/env.go
+++ b/taskfile/env.go
@@ -49,11 +49,23 @@ func baseEnvWithDotenv(dotenv map[string]string) []string {
 // buildEnv composes the environment used to run a task's commands:
 //
 //  1. start from r.BaseEnv (os env + global dotenv),
-//  2. add task-level dotenv (only for keys not already present),
-//  3. overlay task vars,
-//  4. overlay task env, resolving any ${VAR} cross-references.
-func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string) ([]string, error) {
+//  2. overlay parentEnv (only set when invoked as a sub-task via `cmds:
+//     - task: X`; matches shell-function semantics so a parent's `env:`
+//     block flows down to its children),
+//  3. add task-level dotenv (only for keys not already present),
+//  4. overlay task vars,
+//  5. overlay task env, resolving any ${VAR} cross-references.
+func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string, parentEnv []string) ([]string, error) {
 	env := slices.Clone(r.BaseEnv)
+
+	// Inherited parent env wins over BaseEnv (a parent's `env: { GOOS: linux }`
+	// must override the OS GOOS for child tasks). Child task.dotenv/vars/env
+	// then layer on top — the child still gets the final say.
+	for _, e := range parentEnv {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			env = setEnv(env, k, v)
+		}
+	}
 
 	if len(task.Dotenv) > 0 {
 		taskDotenv, err := loadDotenvFiles(dir, task.Dotenv, make(map[string]struct{}))

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -98,7 +98,23 @@ func (l *includeLoader) load() (*Config, error) {
 	}
 
 	l.root.DotenvVars = l.dotenvVars
+	if err := validateDefaultTask(l.root); err != nil {
+		return nil, err
+	}
 	return l.root, nil
+}
+
+// validateDefaultTask ensures that a top-level `default:` field references
+// a real task. Catching this at load time gives the user a clear error
+// instead of the generic "task not found" they'd otherwise see at run time.
+func validateDefaultTask(c *Config) error {
+	if c.Default == "" {
+		return nil
+	}
+	if _, ok := c.Tasks[c.Default]; ok {
+		return nil
+	}
+	return fmt.Errorf("top-level default: %q does not reference any defined task", c.Default)
 }
 
 type includeRequest struct {

--- a/taskfile/subtask_env_test.go
+++ b/taskfile/subtask_env_test.go
@@ -1,0 +1,335 @@
+package taskfile
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Top-level `default:` field ---------------------------------------------
+
+func TestParseTopLevelDefaultField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+default: build
+tasks:
+  build:
+    cmd: go build .
+`), 0o644))
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "build", tf.Default)
+}
+
+func TestLoadWithIncludesRejectsUnknownDefault(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+default: missing
+tasks:
+  build:
+    cmd: go build .
+`), 0o644))
+
+	_, err := LoadWithIncludes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"missing"`)
+	assert.Contains(t, err.Error(), "default:")
+}
+
+func TestLoadWithIncludesAcceptsDefaultPointingToIncludedTask(t *testing.T) {
+	// The validator runs after includes are merged so a top-level
+	// `default:` may reference a namespaced task pulled in via `includes:`.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+default: cli:build
+includes:
+  - cli
+`,
+		"cli/gogo.yaml": `version: "1"
+tasks:
+  build:
+    cmd: echo cli build
+`,
+	})
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "cli:build", tf.Default)
+	assert.Contains(t, tf.Tasks, "cli:build")
+}
+
+func TestDefaultFieldRoundtripsThroughLoad(t *testing.T) {
+	// Smoke test: top-level `default:` survives parsing and (when valid)
+	// makes it through include resolution to the final Config.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+default: dev
+tasks:
+  dev:
+    cmd: echo dev
+`), 0o644))
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", tf.Default)
+}
+
+// --- Env propagation --------------------------------------------------------
+
+func TestSubTaskInheritsParentEnv(t *testing.T) {
+	// The classic case from ai/evals/gogo.yaml: a parent `env:` block must
+	// reach the sub-task without the user having to shell out to `gogo`.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Env:  map[string]string{"TESTSET_SIZE": "2", "MIRROR_FS": "1"},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "child", (*execs)[0].Task)
+	assert.Equal(t, "2", envValue((*execs)[0].Env, "TESTSET_SIZE"))
+	assert.Equal(t, "1", envValue((*execs)[0].Env, "MIRROR_FS"))
+}
+
+func TestSubTaskOwnEnvOverridesParent(t *testing.T) {
+	// Per-key precedence: when the child also declares an env entry, the
+	// child's value wins. This is the same rule that applies to BaseEnv vs
+	// task.env, just one level up the call stack.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Env:  map[string]string{"MODE": "from-parent", "SHARED": "parent-only"},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Env:  map[string]string{"MODE": "from-child"},
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "from-child", envValue((*execs)[0].Env, "MODE"), "child env wins per-key")
+	assert.Equal(t, "parent-only", envValue((*execs)[0].Env, "SHARED"), "non-overlapping parent keys still flow through")
+}
+
+func TestSubTaskEnvVisibleInCmdExpansion(t *testing.T) {
+	// End-to-end: parent env propagates down so the shell that runs the
+	// child cmd has the parent's env in its environment. gogo itself does
+	// not pre-expand ${VAR} from env (that's the shell's job at runtime),
+	// so we assert on the child's Env slice rather than the rendered cmd.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Env:  map[string]string{"GREETING": "hello"},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Cmds: []Cmd{{Cmd: "echo ${GREETING}"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "echo ${GREETING}", (*execs)[0].Command, "gogo leaves ${VAR} from env for the shell")
+	assert.Equal(t, "hello", envValue((*execs)[0].Env, "GREETING"), "and the env reaches the shell")
+}
+
+func TestSubTaskInheritanceIsTransitive(t *testing.T) {
+	// parent -> mid -> leaf: the leaf must see env declared all the way up
+	// the chain. Each level may layer additional env on top.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Env:  map[string]string{"FROM_PARENT": "P"},
+				Cmds: []Cmd{{Task: "mid"}},
+			},
+			"mid": {
+				Env:  map[string]string{"FROM_MID": "M"},
+				Cmds: []Cmd{{Task: "leaf"}},
+			},
+			"leaf": {
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "P", envValue((*execs)[0].Env, "FROM_PARENT"))
+	assert.Equal(t, "M", envValue((*execs)[0].Env, "FROM_MID"))
+}
+
+func TestDepsDoNotInheritParentEnv(t *testing.T) {
+	// Deps run before the parent's body and are conceptually prerequisites,
+	// not sequenced sub-calls. They must NOT see parent.env, so a parent's
+	// "set up the env, then run me" workflow stays predictable.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Env:  map[string]string{"PARENT_ONLY": "yes"},
+				Deps: []Dep{{Task: "prereq"}},
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+			"prereq": {
+				Cmds: []Cmd{{Cmd: "echo prereq"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+
+	// Find the prereq exec and check its env doesn't carry PARENT_ONLY.
+	var prereqExec *Execution
+	for i := range *execs {
+		if (*execs)[i].Task == "prereq" {
+			prereqExec = &(*execs)[i]
+		}
+	}
+	require.NotNil(t, prereqExec, "prereq should have run")
+	assert.Empty(t, envValue(prereqExec.Env, "PARENT_ONLY"))
+}
+
+func TestSubTaskCallBypassesMemoizationWhenParentEnvDiffers(t *testing.T) {
+	// Two parents that both call the same child must each get their own
+	// child execution with their own env. Without bypass, the second call
+	// would short-circuit on r.runs and silently drop the second env.
+	dir := t.TempDir()
+
+	var childCalls atomic.Int64
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"all": {
+				Cmds: []Cmd{
+					{Task: "p1"},
+					{Task: "p2"},
+				},
+			},
+			"p1": {
+				Env:  map[string]string{"WHO": "one"},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"p2": {
+				Env:  map[string]string{"WHO": "two"},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Cmds: []Cmd{{Cmd: "echo ${WHO}"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+	r.ShellRunner = &fakeShellRunner{
+		execs: execs,
+		runFunc: func(req ShellCommand) error {
+			if req.Kind == ShellCommandTask && req.TaskName == "child" {
+				childCalls.Add(1)
+			}
+			return nil
+		},
+	}
+
+	require.NoError(t, r.Run("all", ""))
+
+	assert.Equal(t, int64(2), childCalls.Load(), "child must run once per call site")
+
+	whos := []string{}
+	for _, e := range *execs {
+		if e.Task == "child" {
+			whos = append(whos, envValue(e.Env, "WHO"))
+		}
+	}
+	slices.Sort(whos)
+	assert.Equal(t, []string{"one", "two"}, whos)
+}
+
+func TestRunPublicAPIDoesNotPropagateEnv(t *testing.T) {
+	// Runner.Run is the public top-level entry point: there is no parent
+	// task, so no env propagation. This guards the contract that tests and
+	// programmatic callers don't accidentally pull the calling shell's env
+	// into a task that was previously isolated.
+	dir := t.TempDir()
+	t.Setenv("LEAK_FROM_CALLER", "should-not-appear")
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"only-mine": {
+				Env:  map[string]string{"OWN": "yes"},
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir) // BaseEnv = nil, so OS env is not in BaseEnv
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("only-mine", ""))
+
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "yes", envValue((*execs)[0].Env, "OWN"))
+	assert.Empty(t, envValue((*execs)[0].Env, "LEAK_FROM_CALLER"))
+}
+
+func TestParentVarsAlsoFlowDownAsEnv(t *testing.T) {
+	// Vars get exported as env entries by buildEnv (existing behaviour);
+	// since parent's env propagates, parent's vars-as-env do too. Verifying
+	// here so a future change can't silently drop this. Vars are NOT
+	// substituted into the child's cmd template (that's a separate code
+	// path), but they DO show up in the env passed to the shell.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"parent": {
+				Vars: map[string]Var{"PARENT_VAR": {Value: "hello"}},
+				Cmds: []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "hello", envValue((*execs)[0].Env, "PARENT_VAR"))
+}

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -85,7 +85,7 @@ func (r *Runner) Run(name, cliArgs string, extraVars ...map[string]Var) error {
 
 	// Each call site with extra vars is a distinct execution — bypass memoization.
 	if hasExtraVars(extraVars) {
-		return r.run(resolved, cliArgs, extraVars)
+		return r.run(resolved, cliArgs, extraVars, nil)
 	}
 
 	entry, _ := r.runs.LoadOrStore(resolved, &taskRun{})
@@ -94,8 +94,25 @@ func (r *Runner) Run(name, cliArgs string, extraVars ...map[string]Var) error {
 		return fmt.Errorf("internal error: unexpected runs entry type %T for task %q", entry, resolved)
 	}
 	return tr.do(func() error {
-		return r.run(resolved, cliArgs, nil)
+		return r.run(resolved, cliArgs, nil, nil)
 	})
+}
+
+// runSubTask is the entry point for `cmds: - task: X` calls. Each sub-task
+// invocation propagates the parent task's resolved env down so child tasks
+// see what the parent declared in its `env:` block (matching shell-function
+// semantics). Memoization is always bypassed because two parents calling the
+// same child with different env are genuinely different executions.
+func (r *Runner) runSubTask(name, cliArgs string, extraVars map[string]Var, parentEnv []string) error {
+	resolved, err := r.resolveTask(name)
+	if err != nil {
+		return err
+	}
+	var ev []map[string]Var
+	if len(extraVars) > 0 {
+		ev = []map[string]Var{extraVars}
+	}
+	return r.run(resolved, cliArgs, ev, parentEnv)
 }
 
 // hasExtraVars reports whether the variadic extraVars carries any overrides.
@@ -104,8 +121,9 @@ func hasExtraVars(extraVars []map[string]Var) bool {
 }
 
 // run executes a task's body. Deduplication is handled by Run; this method
-// always runs the task, so recursive calls from runCmds must go through Run.
-func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var) error {
+// always runs the task, so recursive calls from runCmds must go through Run
+// (or runSubTask, which threads the parent env down).
+func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, parentEnv []string) error {
 	task := r.tf.Tasks[resolved]
 
 	if !matchesPlatform(task.Platforms) {
@@ -128,7 +146,7 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var) error
 		return err
 	}
 
-	env, err := r.buildEnv(&task, dir, vars)
+	env, err := r.buildEnv(&task, dir, vars, parentEnv)
 	if err != nil {
 		return err
 	}
@@ -162,7 +180,11 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var) error
 func (r *Runner) runCmds(taskName string, cmds []Cmd, vars map[string]string, cliArgs, dir string, env []string, useOpRun, silent bool) error {
 	for _, cmd := range cmds {
 		if cmd.Task != "" {
-			if err := r.Run(cmd.Task, cliArgs, cmd.Vars); err != nil {
+			// `task: X` sub-calls inherit the parent's resolved env so a
+			// task-level `env:` block flows down without the user having to
+			// shell out to `gogo` to plumb env through. Child env still wins
+			// per-key (composed inside buildEnv).
+			if err := r.runSubTask(cmd.Task, cliArgs, cmd.Vars, env); err != nil {
 				return err
 			}
 			continue

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -6,6 +6,7 @@ type Config struct {
 	Includes   []string              `yaml:"includes"`
 	Flatten    []string              `yaml:"flatten"` // YAML files whose tasks merge into this config without a namespace
 	Dotenv     []string              `yaml:"dotenv"`
+	Default    string                `yaml:"default"` // task to run when none is given on the CLI; replaces the convention of declaring a `default` task
 	Vars       map[string]Var        `yaml:"vars"`
 	Sources    map[string]StringList `yaml:"sources"` // named source presets, referenced from task.Sources by name
 	Tasks      map[string]Task       `yaml:"tasks"`


### PR DESCRIPTION
## What

Two related quality-of-life improvements that together drop ~80 lines of boilerplate across the corpus:

### 1. Top-level `default:` field

Names which task runs when `gogo` is invoked with no positional arg, replacing the no-op trampoline task pattern:

```yaml
# Before — appears verbatim in 9+ projects
tasks:
  default:
    cmds:
      - task: dev
  dev: { ... }

# After
default: dev
tasks:
  dev: { ... }
```

A `default:` referencing a non-existent task is rejected at load time. If `default:` is unset, gogo still falls back to running a task literally named `default` — fully backward compatible. An explicit positional arg always wins (`gogo build` runs `build` even when `default: dev` is declared).

### 2. Parent → child env propagation

`cmds: - task: X` invocations now inherit the parent's resolved environment. The pain this solves is documented verbatim in `ai/evals/gogo.yaml`:

```yaml
# Note: shells out to `gogo` so env vars propagate into the sub-tasks
# (Task's `env:` block is NOT inherited by `task: foo` sub-calls — the
# vars must be exported in the shell that invokes the sub-task).
smoke-llm:
  cmds:
    - TESTSET_SIZE=2 DOC_LIMIT=2 MIRROR_FS=1 gogo gen:dev
    - MIRROR_FS=1 gogo gordon:knowledge
    - gogo ingest:smoke
```

Becomes:

```yaml
smoke-llm:
  env:
    TESTSET_SIZE: "2"
    DOC_LIMIT: "2"
    MIRROR_FS: "1"
  cmds:
    - task: gen:dev
    - task: gordon:knowledge
    - task: ingest:smoke
```

## Semantics

- **Only sub-task calls (`cmds: - task: X`) inherit env**, not deps. Deps are prerequisites that run before the parent's body and remain isolated — guarded by `TestDepsDoNotInheritParentEnv`.
- **Child wins per-key.** A child's own `env:` declaration overrides the inherited parent value for that key; non-overlapping parent keys flow through unchanged.
- **Inheritance is transitive.** `parent → mid → leaf` accumulates env at each level.
- **Memoization is bypassed** for sub-task calls. Two parents calling the same child with different env each get their own execution — without bypass, the second call would silently short-circuit on the first call's result. Same rule that already applies to `extraVars`.
- **Public `Runner.Run` does not propagate** anything. Top-level invocations stay isolated; programmatic callers see no behavior change.

### Composition order in `buildEnv`

```
1. BaseEnv          (os env + global dotenv)
2. parentEnv        (NEW — sub-task only)
3. task.dotenv      (only fills missing keys)
4. task.vars        (overlays)
5. task.env         (overlays)
```

Documented in `docs/features/variables/#parent-to-child-env-propagation`.

## Changes

- **`taskfile/types.go`** — `Default string` on `Config`.
- **`taskfile/includes.go`** — `validateDefaultTask` runs after include merge so `default:` may reference a namespaced task pulled in from `includes:`.
- **`taskfile/task_execution.go`** — new `Runner.runSubTask` entry point; `r.run` and `r.buildEnv` thread `parentEnv []string` through.
- **`taskfile/env.go`** — `buildEnv` overlays `parentEnv` after `BaseEnv`.
- **`main.go`** — `defaultTaskName` helper picks `tf.Default` over the arg-parser default.
- **`taskfile/subtask_env_test.go`** *(new)* — 11 tests: parsing, load-time validation, default-task resolution, parent→child inheritance, child-overrides-parent, transitivity, deps-don't-inherit, memoization bypass, public-API isolation, vars-as-env propagation.
- **`app_test.go`** — 4 new tests for the CLI default resolution and load-time error.
- **`taskfile/dotenv_test.go`** — mechanical: extra `nil` arg for the new `buildEnv` parameter.
- **Docs** — `task-file-syntax/` adds a "Default Task" section + sub-task env note; `variables/` adds a "Parent-to-child Env Propagation" section. `AGENTS.md` documents the new precedence and the runSubTask path.

## Backward compatibility

Fully backward compatible:
- A task literally named `default` still runs as today when no top-level `default:` is set.
- Existing `cmds: - task: X` patterns that previously didn't see parent env now do see it. **This is a behavior change**, but in the direction of "the thing users actually expected" — search the corpus for the documented `Note: shells out to gogo` workaround. Any project that *relied* on isolation was almost certainly working around this gap, not depending on it.
- Public `Runner.Run` signature unchanged.

End-to-end smoke verified against `/bin/sh`: parent `env:` flows down, the shell expands `$VAR` correctly, and a `default:` typo errors at load time with a clear message.