### PR TITLE
Resolve var-in-var references transitively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,8 +131,12 @@ The Go toolchain version comes from `go.mod` (`go 1.26.3`). Tests run with
   `Runner.runSubTask` — deps do NOT (they're prerequisites, not sequenced
   sub-calls; see `TestDepsDoNotInheritParentEnv`). Memoization is bypassed
   whenever extraVars or parentEnv is non-nil so two call sites with
-  different context don't collapse into one execution. The built-in
-  `GIT_*` resolver in `taskfile/gitvars.go` is wired through
+  different context don't collapse into one execution. Vars in `vars:`
+  resolve lazily through a recursive lookup in `resolveAllVars` (see
+  `taskfile/vars.go`); they may reference each other and the built-in
+  `GIT_*` family transitively, declaration order is irrelevant, and
+  cycles short-circuit to the empty string. The built-in `GIT_*`
+  resolver in `taskfile/gitvars.go` is wired through
   `Runner.builtinLookup` and is consulted *after* user vars / CLI_ARGS
   but *before* the process environment by `expandVars`,
   `resolveEnvValue`, and `checkRequires`. Watch mode must call

--- a/docs/features/variables/index.md
+++ b/docs/features/variables/index.md
@@ -51,6 +51,30 @@ tasks:
     cmd: deploy --env {{ "{{" }}.ENV}}
 ```
 
+## Variable References Inside Variables
+
+A variable's value (or `sh:` command) can reference any other variable, including [built-ins](#built-in-variables). References are resolved transitively at run time and declaration order is irrelevant:
+
+```yaml
+vars:
+  GIT_TAG: "{{ "{{" }}.GIT_TAG}}"          # built-in
+  LDFLAGS: "-X main.Version={{ "{{" }}.GIT_TAG}} -X main.Commit={{ "{{" }}.GIT_COMMIT}}"
+
+tasks:
+  build:
+    cmd: go build -ldflags '{{ "{{" }}.LDFLAGS}}' .
+```
+
+The `sh:` form is template-expanded too, so a shell command can be parameterised by other vars:
+
+```yaml
+vars:
+  IMAGE: cagent-proxy
+  LATEST: { sh: "ls -1 dist/{{ "{{" }}.IMAGE}}-*.tar | sort | tail -1" }
+```
+
+Cycles — `A: "{{ "{{" }}.B}}"`, `B: "{{ "{{" }}.A}}"` — short-circuit to the empty string rather than looping forever, mirroring how task `env:` cross-references behave.
+
 ## Built-in Variables
 
 | Variable | Description |
@@ -185,5 +209,7 @@ When resolving `{{ "{{" }}.VAR}}` or `${VAR}` inside a command, gogo looks up th
 2. `CLI_ARGS` (if the lookup is for that name)
 3. Built-in variables (`GIT_*`)
 4. The process environment
+
+Var bodies (the `value:` and `sh:` of another variable) use a slightly tighter chain — only other vars and built-ins, no `CLI_ARGS` or process env. This keeps `vars:` deterministic and free of CLI/shell context.
 
 Unknown `${VAR}` references are left intact for the shell to expand. Unknown `{{ "{{" }}.VAR}}` templates are left verbatim.

--- a/taskfile/transitive_vars_test.go
+++ b/taskfile/transitive_vars_test.go
@@ -1,0 +1,292 @@
+package taskfile
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCmdAndCapture runs `task` once and returns the resolved cmd string the
+// shell runner would have received. It's a thin convenience around the
+// fakeShellRunner / captureExecs pair used elsewhere.
+func runCmdAndCapture(t *testing.T, tf *Config) string {
+	t.Helper()
+	r := newTestRunner(t, tf, tf.Dir)
+	execs := captureExecs(r)
+	require.NoError(t, r.Run("show", ""))
+	require.Len(t, *execs, 1)
+	return (*execs)[0].Command
+}
+
+func TestVarsTransitiveExpansionSimpleChain(t *testing.T) {
+	// The headline bug: `{{.A}}` referenced from another var's value used to
+	// land in the final cmd as a literal. Now it resolves transitively.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"GREETING": {Value: "hello"},
+			"MESSAGE":  {Value: "{{.GREETING}} world"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.MESSAGE}}"}}},
+		},
+	}
+	assert.Equal(t, "echo hello world", runCmdAndCapture(t, tf))
+}
+
+func TestVarsTransitiveExpansionForwardReference(t *testing.T) {
+	// Map iteration is randomised, so this also catches any "must declare
+	// before use" assumption \u2014 A references B even though B is alphabetically
+	// later. Lazy resolution makes declaration order irrelevant.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"A": {Value: "{{.B}}"},
+			"B": {Value: "resolved"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.A}}"}}},
+		},
+	}
+	assert.Equal(t, "echo resolved", runCmdAndCapture(t, tf))
+}
+
+func TestVarsTransitiveExpansionShellSyntax(t *testing.T) {
+	// ${VAR} works anywhere {{.VAR}} works. Same single source of truth.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"A": {Value: "alpha"},
+			"B": {Value: "${A}-beta"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.B}}"}}},
+		},
+	}
+	assert.Equal(t, "echo alpha-beta", runCmdAndCapture(t, tf))
+}
+
+func TestVarsTransitiveCycleResolvesToEmpty(t *testing.T) {
+	// Cycles must not loop; matching how task.env cross-references behave,
+	// the cycle short-circuits to an empty value so the rest of the
+	// expansion can complete.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"A": {Value: "[{{.B}}]"},
+			"B": {Value: "[{{.A}}]"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.A}}"}}},
+		},
+	}
+	// A -> B -> A (cycle, "" returned) -> B becomes "[]" -> A becomes "[[]]"
+	assert.Equal(t, "echo [[]]", runCmdAndCapture(t, tf))
+}
+
+func TestVarsTransitiveSelfCycleResolvesToEmpty(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"X": {Value: "[{{.X}}]"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.X}}"}}},
+		},
+	}
+	assert.Equal(t, "echo []", runCmdAndCapture(t, tf))
+}
+
+func TestVarsTransitiveExpansionLDFLAGSPattern(t *testing.T) {
+	// The exact cagent-proxy / gordon shape that motivated this fix. Before
+	// the change, {{.LDFLAGS}} substituted into the cmd carried `{{.GIT_TAG}}`
+	// and `{{.GIT_COMMIT}}` along as literals.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"GIT_TAG":    {Value: "v1.2.3"},
+			"GIT_COMMIT": {Value: "abcdef0"},
+			"LDFLAGS":    {Value: `-X main.Version={{.GIT_TAG}} -X main.Commit={{.GIT_COMMIT}}`},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: `go build -ldflags '{{.LDFLAGS}}' .`}}},
+		},
+	}
+	assert.Equal(t,
+		`go build -ldflags '-X main.Version=v1.2.3 -X main.Commit=abcdef0' .`,
+		runCmdAndCapture(t, tf),
+	)
+}
+
+func TestVarsReferenceBuiltinGitVars(t *testing.T) {
+	// After PR #5, GIT_COMMIT is a built-in. A user-defined LDFLAGS that
+	// references it without re-declaring the var must still resolve.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"LDFLAGS": {Value: "-X main.Commit={{.GIT_COMMIT}}"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.LDFLAGS}}"}}},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = &fakeShellRunner{
+		outputFunc: func(req ShellCommand) ([]byte, error) {
+			if req.Command == "git rev-parse HEAD" {
+				return []byte("deadbeef\n"), nil
+			}
+			return nil, errors.New("unexpected: " + req.Command)
+		},
+	}
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("show", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "echo -X main.Commit=deadbeef", (*execs)[0].Command)
+}
+
+func TestVarsUserOverrideStillBeatsBuiltin(t *testing.T) {
+	// A user-defined GIT_COMMIT must override the built-in even when consumed
+	// transitively via another var. Guards the precedence rule.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"GIT_COMMIT": {Value: "user-pinned"},
+			"LDFLAGS":    {Value: "-X main.Commit={{.GIT_COMMIT}}"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.LDFLAGS}}"}}},
+		},
+	}
+	assert.Equal(t, "echo -X main.Commit=user-pinned", runCmdAndCapture(t, tf))
+}
+
+func TestVarsShCommandSeesOtherVars(t *testing.T) {
+	// The `sh:` form is template-expanded too, so a shell command can be
+	// parameterised by other vars. This unblocks patterns like
+	// `sh: ls -1 dist/{{.IMAGE}}-*.tar`.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"NAME":  {Value: "world"},
+			"GREET": {Sh: "echo hello-{{.NAME}}"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.GREET}}"}}},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	// fakeShellRunner.Output returns "sh:" + Command by default \u2014 use it as
+	// a faithful echo so we can verify the templated cmdline reached the
+	// shell after expansion.
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("show", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "echo sh:echo hello-world", (*execs)[0].Command)
+}
+
+func TestVarsTaskScopeOverridesGlobal(t *testing.T) {
+	// Pre-existing precedence (task vars > global vars) must still hold
+	// after the lazy refactor.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"ENV": {Value: "global"},
+		},
+		Tasks: map[string]Task{
+			"show": {
+				Vars: map[string]Var{"ENV": {Value: "task"}},
+				Cmds: []Cmd{{Cmd: "echo {{.ENV}}"}},
+			},
+		},
+	}
+	assert.Equal(t, "echo task", runCmdAndCapture(t, tf))
+}
+
+func TestVarsExtraVarsOverrideTaskVarsAndExpandTransitively(t *testing.T) {
+	// Call-site `vars:` should override the called task's own vars *and*
+	// participate in transitive expansion \u2014 a value passed in at the call
+	// site can reference the task's other vars by name.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"caller": {
+				Cmds: []Cmd{{
+					Task: "callee",
+					Vars: map[string]Var{
+						"GREETING": {Value: "Hi from {{.LOCATION}}"},
+					},
+				}},
+			},
+			"callee": {
+				Vars: map[string]Var{
+					"GREETING": {Value: "default"},
+					"LOCATION": {Value: "Paris"},
+				},
+				Cmds: []Cmd{{Cmd: "echo {{.GREETING}}"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("caller", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "echo Hi from Paris", (*execs)[0].Command)
+}
+
+func TestVarsShCommandFailureIsSurfaced(t *testing.T) {
+	// A failing `sh:` should still propagate as an error to the caller, so
+	// users learn about the problem instead of silently getting "".
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"BAD": {Sh: "exit 1"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.BAD}}"}}},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	r.ShellRunner = &fakeShellRunner{
+		outputFunc: func(req ShellCommand) ([]byte, error) {
+			return nil, errors.New("exit 1")
+		},
+	}
+
+	err := r.Run("show", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving variable (sh: exit 1)")
+}
+
+func TestVarsTaskFileDirIsAlwaysAvailable(t *testing.T) {
+	// The pre-existing TASK_FILE_DIR built-in must still be resolvable from
+	// inside another var's body, not just inside cmds.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Vars: map[string]Var{
+			"OUT_PATH": {Value: "{{.TASK_FILE_DIR}}/dist"},
+		},
+		Tasks: map[string]Task{
+			"show": {Cmds: []Cmd{{Cmd: "echo {{.OUT_PATH}}"}}},
+		},
+	}
+	assert.Equal(t, "echo "+dir+"/dist", runCmdAndCapture(t, tf))
+}

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -88,63 +88,123 @@ func expandTaskTemplates(t *Task) {
 	}
 }
 
-// resolveAllVars computes the effective variables for a task, including extra vars from call sites.
+// resolveAllVars computes the effective variables for a task. Vars are
+// resolved lazily and may reference each other (transitively) via {{.OTHER}}
+// or ${OTHER} — declaration order in YAML is irrelevant. Cycles resolve to
+// the empty string (matching how task.env cross-references behave).
+//
+// Precedence on a name collision: extra (call-site) > task > global. Within
+// each layer the value is template-expanded against everything below it,
+// then against the built-in lookup (e.g. {{.GIT_COMMIT}}).
 func (r *Runner) resolveAllVars(task *Task, dir string, extraVars []map[string]Var) (map[string]string, error) {
-	vars, err := r.resolveVars(task, dir)
-	if err != nil {
-		return nil, err
+	type source struct {
+		v   Var
+		dir string // working directory for `sh:` evaluation
 	}
 
+	// Build a unified source map. Later assignments win; we layer global
+	// vars first, then task vars, then any call-site extra vars.
+	sources := make(map[string]source, len(r.tf.Vars)+len(task.Vars))
+	for k, v := range r.tf.Vars {
+		sources[k] = source{v, r.tf.Dir}
+	}
+	for k, v := range task.Vars {
+		sources[k] = source{v, dir}
+	}
 	for _, ev := range extraVars {
-		if err := r.addVars(vars, ev, dir); err != nil {
-			return nil, err
+		for k, v := range ev {
+			sources[k] = source{v, dir}
 		}
 	}
 
-	return vars, nil
-}
-
-// resolveVars computes the effective variables for a task.
-func (r *Runner) resolveVars(task *Task, taskDir string) (map[string]string, error) {
 	resolved := map[string]string{
-		"TASK_FILE_DIR": taskDir,
+		"TASK_FILE_DIR": dir,
 	}
-	if err := r.addVars(resolved, r.tf.Vars, r.tf.Dir); err != nil {
-		return nil, err
+	visiting := make(map[string]struct{})
+	var firstErr error
+
+	var lookup func(key string) (string, bool)
+	lookup = func(key string) (string, bool) {
+		if firstErr != nil {
+			return "", false
+		}
+		if v, ok := resolved[key]; ok {
+			return v, true
+		}
+		// Cycles short-circuit to the empty string. Treating the value as
+		// "resolved" lets the rest of the expansion finish so the user gets
+		// a complete (if mostly empty) value to debug from.
+		if _, onPath := visiting[key]; onPath {
+			return "", true
+		}
+		s, ok := sources[key]
+		if !ok {
+			// Unknown user-vars fall through to gogo built-ins. CLI_ARGS, OS
+			// env and the cliArgs fallback are NOT consulted here — those
+			// only apply when expanding command strings, not var bodies.
+			return r.builtinLookup(key)
+		}
+		visiting[key] = struct{}{}
+		defer delete(visiting, key)
+
+		var value string
+		if s.v.Sh != "" {
+			// Expand template references inside the shell command itself so
+			// patterns like `sh: echo {{.IMAGE}}-{{.GIT_TAG}}.tar` work.
+			cmdLine := expandTemplates(s.v.Sh, lookup)
+			out, err := r.ShellRunner.Output(ShellCommand{
+				Kind:    ShellCommandVar,
+				Command: cmdLine,
+				Dir:     s.dir,
+			})
+			if err != nil {
+				firstErr = fmt.Errorf("resolving variable (sh: %s): %w", s.v.Sh, err)
+				return "", true
+			}
+			value = strings.TrimSpace(string(out))
+		} else {
+			value = expandTemplates(s.v.Value, lookup)
+		}
+		resolved[key] = value
+		return value, true
 	}
-	if err := r.addVars(resolved, task.Vars, taskDir); err != nil {
-		return nil, err
+
+	// Force-resolve every declared name so the returned map is complete:
+	// downstream consumers (env composition, requires, expandVars on cmd
+	// strings) read from a flat map and don't go through this lookup again.
+	for _, name := range slices.Sorted(maps.Keys(sources)) {
+		lookup(name)
+		if firstErr != nil {
+			return nil, firstErr
+		}
 	}
 	return resolved, nil
 }
 
-// addVars resolves each Var in src (sorted for determinism) and writes it into dst.
-func (r *Runner) addVars(dst map[string]string, src map[string]Var, dir string) error {
-	for _, k := range slices.Sorted(maps.Keys(src)) {
-		v, err := r.resolveVar(src[k], dir)
-		if err != nil {
-			return err
+// expandTemplates substitutes ${VAR} and {{.VAR}} references in s using the
+// supplied lookup. Unknown ${VAR} references are left for the shell to
+// expand; unknown {{.VAR}} templates are left verbatim. Both forms share a
+// single lookup so callers can layer vars / CLI_ARGS / built-ins / env in
+// whatever priority makes sense for their context.
+func expandTemplates(s string, lookup func(string) (string, bool)) string {
+	// Expand ${VAR} first. This won't touch {{.VAR}} templates since they
+	// don't start with $. Unknown variables are left as ${KEY} for the shell.
+	s = os.Expand(s, func(key string) string {
+		if val, ok := lookup(key); ok {
+			return val
 		}
-		dst[k] = v
-	}
-	return nil
-}
-
-// resolveVar evaluates a single variable, running a shell command if needed.
-func (r *Runner) resolveVar(v Var, dir string) (string, error) {
-	if v.Sh == "" {
-		return v.Value, nil
-	}
-
-	out, err := r.ShellRunner.Output(ShellCommand{
-		Kind:    ShellCommandVar,
-		Command: v.Sh,
-		Dir:     dir,
+		return "${" + key + "}"
 	})
-	if err != nil {
-		return "", fmt.Errorf("resolving variable (sh: %s): %w", v.Sh, err)
-	}
-	return strings.TrimSpace(string(out)), nil
+
+	// Then replace {{.VAR}} templates. Unknown templates are left as-is so
+	// run-time behavior matches expandConfigEnvTemplates at parse time.
+	return templatePattern.ReplaceAllStringFunc(s, func(match string) string {
+		key := templatePattern.FindStringSubmatch(match)[1]
+		if val, ok := lookup(key); ok {
+			return val
+		}
+		return match
+	})
 }
 
 // expandVars substitutes template and shell variables in a command string.
@@ -163,7 +223,7 @@ func (r *Runner) resolveVar(v Var, dir string) (string, error) {
 // CLI_ARGS but *before* the process environment, so a user-defined var with
 // the same name as a built-in (e.g. GIT_COMMIT) always wins.
 func expandVars(s string, vars map[string]string, cliArgs string, builtin func(string) (string, bool)) string {
-	lookup := func(key string) (string, bool) {
+	return expandTemplates(s, func(key string) (string, bool) {
 		if val, ok := vars[key]; ok {
 			return val, true
 		}
@@ -176,25 +236,6 @@ func expandVars(s string, vars map[string]string, cliArgs string, builtin func(s
 			}
 		}
 		return os.LookupEnv(key)
-	}
-
-	// Expand ${VAR} first. This won't touch {{.VAR}} templates since they
-	// don't start with $. Unknown variables are left as ${KEY} for the shell.
-	s = os.Expand(s, func(key string) string {
-		if val, ok := lookup(key); ok {
-			return val
-		}
-		return "${" + key + "}"
-	})
-
-	// Then replace {{.VAR}} templates. Unknown templates are left as-is so
-	// run-time behavior matches expandConfigEnvTemplates at parse time.
-	return templatePattern.ReplaceAllStringFunc(s, func(match string) string {
-		key := templatePattern.FindStringSubmatch(match)[1]
-		if val, ok := lookup(key); ok {
-			return val
-		}
-		return match
 	})
 }
 


### PR DESCRIPTION
## What

Fixes a silent bug in `vars:` resolution. A variable's value (or `sh:` command) that contained another `{{.VAR}}` or `${VAR}` reference was returned verbatim — the inner reference ended up literal in the final command:

```yaml
# Before — looks fine, but quietly broken
vars:
  LDFLAGS: "-X main.Commit={{.GIT_COMMIT}}"
tasks:
  build:
    cmd: go build -ldflags '{{.LDFLAGS}}' .

# What actually reached /bin/sh:
go build -ldflags '-X main.Commit={{.GIT_COMMIT}}' .
#                                  ^^^^^^^^^^^^^^^^^ literal, not the SHA
```

The `Commit` field in the resulting binary contained the literal string `{{.GIT_COMMIT}}`. Affects (at least) **10 projects in our corpus** — `cagent-proxy`, `gordon/{proxy,metrics,daily-report}`, the e6ef417/07f281a clones, `ai/cli`, `ai/eval-gen`. Nobody noticed because `GIT_TAG` is the field users typically check; `Commit` was bogus and unread.

End-to-end before/after on the repro:

```sh
$ gogo show     # before
ldflags = '-X main.Commit={{.GIT_COMMIT}} -X main.Version={{.GIT_TAG}}'

$ gogo show     # after
ldflags = '-X main.Commit=02e776...real SHA... -X main.Version=v1.2.3'
```

## How it works

`Runner.resolveAllVars` is rewritten around a lazy, cycle-detected lookup (the same pattern `resolveEnvValue` already uses for `task.env` cross-references):

- All var sources (global → task → call-site extras) are merged into one map; later layers win.
- A recursive `lookup(key)` resolves a name on demand and caches the result. When evaluating a var's body, `expandTemplates` is called with `lookup` as its resolver, so `{{.OTHER}}` inside the body recurses into the same code path.
- The `sh:` command is template-expanded too — patterns like `sh: ls dist/{{.IMAGE}}-*.tar` now work.
- A `visiting` set detects cycles; cycles short-circuit to the empty string (matching task `env:` behaviour) so the rest of the expansion still completes.
- Declaration order is irrelevant — `A: "{{.B}}"` works whether B is declared before or after A in YAML.

A side refactor extracts the shared `expandTemplates(s, lookup)` helper used by both `expandVars` (for cmd strings) and the new var resolver. Same `${VAR}` + `{{.VAR}}` semantics, single source of truth.

### Precedence chain (unchanged for cmd strings; tightened for var bodies)

For **cmd strings** (and env values), unchanged:
1. Task-scoped vars (which override global vars)
2. `CLI_ARGS`
3. Built-in `GIT_*`
4. Process environment

For **var bodies** (the new transitive expansion), only the first three layers — no `CLI_ARGS`, no process env. This keeps `vars:` deterministic and free of CLI/shell context. (Process env was never reachable from var bodies before either, so this is consistent.)

## Tests

`taskfile/transitive_vars_test.go` (new) — 13 tests:

- simple chain, forward reference (alphabetical-order-doesn't-matter), `${VAR}` syntax;
- mutual cycle and self-cycle both resolve to empty;
- the exact cagent-proxy LDFLAGS pattern;
- referencing the built-in `{{.GIT_COMMIT}}` from a user var;
- user override still beats built-in transitively;
- `sh:` command sees other vars (`sh: echo hello-{{.NAME}}`);
- task-scope still overrides global;
- call-site extra vars override task vars *and* expand transitively (a value passed in at the call site can reference the called task's other vars);
- `sh:` failure is surfaced as an error;
- `TASK_FILE_DIR` still resolves from inside another var.

All ~200 existing tests still pass.

## Backward compatibility

This is a **bug-fix** masquerading as a behaviour change. Specifically:

- Var values that contained `{{.X}}` references silently broke before; now they work. Anyone relying on the *literal* string `{{.X}}` ending up in their command is — well, they shouldn't be, and this PR breaks that. I judged that risk negligible (no project in our corpus is doing this on purpose).
- Cycles that previously hung or stack-overflowed are now well-defined empty strings.
- `Sh` commands now see other vars. Previously a `sh:` body containing `{{.X}}` would have been literal and the shell would receive `{{.X}}` text and probably fail on quoting. So this is a strict improvement.
- Public API unchanged.

## Side effect (the nice one)

After this fix, the migration cagent-proxy / gordon-mono / etc. need to drop their `GIT_COMMIT: { sh: git rev-parse HEAD }` block (in favour of the built-in from PR #5) becomes truly drop-in. Today they can't migrate cleanly because their `LDFLAGS` pattern doesn't actually work — they've been getting away with it. After this PR, the migration is a one-line delete.