### PR TITLE
Top-level secrets: block (op://)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,12 @@ The Go toolchain version comes from `go.mod` (`go 1.26.3`). Tests run with
   `Precondition`, or `Var`).
 - **Touching the `op://` path**: the trigger is `hasOpSecrets(env)` over
   the *fully-built* env (so dotenv-sourced secrets count). Don't move the
-  check to before env composition.
+  check to before env composition. The new top-level `secrets:` block in
+  `taskfile/secrets.go` runs as the *last* layer of `buildEnv`, so a
+  `secrets: [X]` reference still feeds the existing `op://` detection.
+  New backends plug in by adding a `case strings.HasPrefix(uri, ...)`
+  branch in `resolveSecretURI` and a scheme constant in
+  `supportedSecretSchemes`.
 - **Editing watch behavior**: source collection is recursive over deps via
   `collectSources`; remember to `r.ResetRan()` between iterations or the
   memoized first run will be returned forever.

--- a/docs/features/secrets/index.md
+++ b/docs/features/secrets/index.md
@@ -4,28 +4,78 @@ title: Secrets
 
 # Secrets
 
-gogo integrates with [1Password CLI](https://developer.1password.com/docs/cli/) to inject secrets as environment variables. When a task's environment contains `op://` references, gogo automatically wraps the command with `op run` to resolve them.
+gogo integrates with [1Password CLI](https://developer.1password.com/docs/cli/) to inject secrets as environment variables. There are two ways to declare them: a centralised top-level `secrets:` block (recommended for projects with several secrets or several tasks) and inline `op://` URIs in a task's `env:` (the original form, still supported).
 
-## Usage
+Both forms feed into the same code path: any `op://` reference in the resolved environment causes the command to be wrapped with `op run`, which performs the actual lookup at exec time. Authentication (Touch ID, biometric, etc.) flows through `op` exactly as it does today.
+
+## Top-level `secrets:` block
+
+Declare each secret once at the top of the file, then reference it by name from the tasks that need it:
+
+```yaml
+secrets:
+  OPENAI_API_KEY: op://Team AI Agent/docker-ai/OPENAI_API_KEY
+  ANTHROPIC_KEY:  op://Team AI Agent/docker-ai/ANTHROPIC_API_KEY
+
+tasks:
+  test:
+    secrets: [OPENAI_API_KEY]
+    cmd: poetry run pytest
+
+  dev:
+    secrets: [OPENAI_API_KEY, ANTHROPIC_KEY]
+    cmd: docker compose up --watch
+```
+
+Three reasons this is preferred over inline URIs once you have more than one or two secrets:
+
+1. **Single source of truth.** Rotating a vault path is a one-line edit instead of a grep across N tasks.
+2. **Per-task allow-list.** A task only sees the secrets it explicitly opts into.
+3. **Forward-compatible.** Adding a new backend (Keychain, AWS, …) later is purely additive.
+
+The map key (`OPENAI_API_KEY`) becomes the env-var name injected into the task. The URI follows the standard [1Password secret reference](https://developer.1password.com/docs/cli/secret-references/) format.
+
+## Inline `op://` (still supported)
+
+The original integration still works. If you have any `op://` URI anywhere in the resolved env (from `task.env`, dotenv, etc.), the command is wrapped with `op run` automatically — no `secrets:` block required:
 
 ```yaml
 tasks:
   deploy:
     env:
       DB_PASSWORD: op://vault/item/field
-      API_KEY: op://vault/api-credentials/key
-    cmd: deploy --password $DB_PASSWORD --api-key $API_KEY
+    cmd: deploy --password $DB_PASSWORD
 ```
 
-The `op://` references use the standard [1Password secret reference](https://developer.1password.com/docs/cli/secret-references/) format.
+You can mix and match: a `secrets:` block for the values you want centralised, plus inline `op://` for one-off references.
 
-## How It Works
+## Precedence
 
-1. Define `op://` references in a task's `env` map
-2. When the task runs, gogo detects the `op://` values
-3. The command is wrapped with `op run`, which resolves all references and injects the actual secret values
-4. `op` handles authentication automatically, including triggering Touch ID when 1Password is locked
+When the same env-var name comes from multiple sources, the order is:
+
+1. `BaseEnv` (OS env + global dotenv)
+2. Inherited parent env (sub-task calls)
+3. Task `dotenv:`
+4. Task `vars:`
+5. Task `env:`
+6. **Task `secrets:`** (highest precedence)
+
+So if a task declares both `env: { OPENAI_API_KEY: DUMMY }` (a placeholder for local dev) and `secrets: [OPENAI_API_KEY]`, the secret wins. Declaring a secret is a strong signal that the value should come from the backend.
+
+## Validation
+
+A `secrets:` reference that names something not declared at the top level fails fast at load time:
+
+```
+task "test" references unknown secret "TYPO"; declare it under top-level `secrets:`
+```
+
+So does an unsupported URI scheme:
+
+```
+secret "X" has unknown backend in "vault://somewhere/else" (supported: op://)
+```
 
 ## Requirements
 
-The `op` CLI must be installed and available on the PATH. Install it from https://developer.1password.com/docs/cli/get-started/
+The `op` CLI must be installed and available on PATH. Install it from <https://developer.1password.com/docs/cli/get-started/>.

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -17,6 +17,7 @@ gogo reads task definitions from a `gogo.yaml` file in the current directory.
 | `dotenv` | list of strings | Paths to `.env` files to load |
 | `vars` | map | Global variables |
 | `sources` | map | Named source-pattern presets, referenced by task `sources:` (see [Sources & Checksums](../sources-checksums/#presets)) |
+| `secrets` | map | Named secret URIs (`op://`, `aws-creds://`, …), referenced by task `secrets:` (see [Secrets](../secrets/)) |
 | `interval` | string | Default polling interval for watch mode (e.g. `500ms`) |
 | `tasks` | map | Task definitions (see below) |
 
@@ -33,6 +34,7 @@ Each task supports the following fields:
 | `dotenv` | list | Paths to `.env` files to load for this task |
 | `env` | map | Environment variables (supports `op://` references for 1Password secrets) |
 | `vars` | map | Task-scoped variables |
+| `secrets` | list or string | Names referencing entries in the top-level `secrets:` map (see [Secrets](../secrets/)) |
 | `sources` | list or string | Glob patterns for incremental builds and watch mode. A bare name resolves to a [source preset](../sources-checksums/#presets) (e.g. `sources: go`) |
 | `generates` | list | Output file patterns for timestamp-based incremental builds |
 | `aliases` | list | Alternative names for the task |

--- a/taskfile/env.go
+++ b/taskfile/env.go
@@ -54,7 +54,11 @@ func baseEnvWithDotenv(dotenv map[string]string) []string {
 //     block flows down to its children),
 //  3. add task-level dotenv (only for keys not already present),
 //  4. overlay task vars,
-//  5. overlay task env, resolving any ${VAR} cross-references.
+//  5. overlay task env, resolving any ${VAR} cross-references,
+//  6. overlay resolved task secrets (highest precedence; an explicit
+//     `secrets: [X]` reference is a stronger signal than a same-named
+//     `env: { X: ... }` entry, and is the only way op:// values reach the
+//     env when secrets are declared centrally).
 func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string, parentEnv []string) ([]string, error) {
 	env := slices.Clone(r.BaseEnv)
 
@@ -85,6 +89,14 @@ func (r *Runner) buildEnv(task *Task, dir string, vars map[string]string, parent
 
 	for _, k := range slices.Sorted(maps.Keys(task.Env)) {
 		env = setEnv(env, k, resolveEnvValue(k, task.Env, vars, r.builtinLookup))
+	}
+
+	secrets, err := r.resolveTaskSecrets(task)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range slices.Sorted(maps.Keys(secrets)) {
+		env = setEnv(env, k, secrets[k])
 	}
 
 	return env, nil

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -101,6 +101,9 @@ func (l *includeLoader) load() (*Config, error) {
 	if err := validateDefaultTask(l.root); err != nil {
 		return nil, err
 	}
+	if err := validateSecrets(l.root); err != nil {
+		return nil, err
+	}
 	return l.root, nil
 }
 
@@ -166,6 +169,7 @@ func (l *includeLoader) loadInclude(req includeRequest) error {
 
 	l.mergeVars(included.Vars)
 	l.mergeSourcePresets(included.Sources)
+	l.mergeSecrets(included.Secrets)
 	return l.mergeTasks(included)
 }
 
@@ -338,6 +342,22 @@ func (l *includeLoader) mergeSourcePresets(presets map[string]StringList) {
 	for k, v := range presets {
 		if _, exists := l.root.Sources[k]; !exists {
 			l.root.Sources[k] = v
+		}
+	}
+}
+
+// mergeSecrets merges child secret declarations into the root. Root entries
+// win conflicts, mirroring the precedence used by mergeVars.
+func (l *includeLoader) mergeSecrets(secrets map[string]string) {
+	if len(secrets) == 0 {
+		return
+	}
+	if l.root.Secrets == nil {
+		l.root.Secrets = make(map[string]string)
+	}
+	for k, v := range secrets {
+		if _, exists := l.root.Secrets[k]; !exists {
+			l.root.Secrets[k] = v
 		}
 	}
 }

--- a/taskfile/secrets.go
+++ b/taskfile/secrets.go
@@ -1,0 +1,88 @@
+package taskfile
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+)
+
+// Supported URI schemes for the secrets backend. Adding a new backend means
+// adding a case in resolveSecretURI and a constant here for the validator.
+const secretSchemeOp = "op://"
+
+// supportedSecretSchemes is the list shown in error messages so users know
+// which prefixes will work. Keep it in sync with resolveSecretURI.
+var supportedSecretSchemes = []string{secretSchemeOp}
+
+// resolveTaskSecrets walks task.Secrets, resolves each reference against
+// the config-level secrets map, and returns a flat map of env entries to
+// inject into the task's environment.
+//
+// Today the only supported backend is op://, which simply passes the URI
+// through as the env value: the existing op-run path then resolves it when
+// the command actually runs (so Touch ID / biometric prompts continue to
+// work the way users already expect).
+//
+// Errors carry the offending name so users can debug a typo quickly.
+func (r *Runner) resolveTaskSecrets(task *Task) (map[string]string, error) {
+	if len(task.Secrets) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(task.Secrets))
+	for _, name := range task.Secrets {
+		uri, ok := r.tf.Secrets[name]
+		if !ok {
+			return nil, fmt.Errorf("task references unknown secret %q (declare it under top-level `secrets:`)", name)
+		}
+		entries, err := resolveSecretURI(name, uri)
+		if err != nil {
+			return nil, fmt.Errorf("resolving secret %q: %w", name, err)
+		}
+		maps.Copy(out, entries)
+	}
+	return out, nil
+}
+
+// resolveSecretURI dispatches to the appropriate backend based on the URI
+// scheme and returns the env entries to inject. Today only op:// is wired
+// up; new schemes plug in by adding another case here.
+func resolveSecretURI(name, uri string) (map[string]string, error) {
+	if strings.HasPrefix(uri, secretSchemeOp) {
+		// Pass-through: the URI itself becomes the env value. The existing
+		// hasOpSecrets / op run wrapper resolves it when the command runs,
+		// so authentication (Touch ID, biometric, etc.) flows through op
+		// exactly as it does for inline op:// references in task.env.
+		return map[string]string{name: uri}, nil
+	}
+	return nil, fmt.Errorf("unknown backend in %q (supported: %s)", uri, strings.Join(supportedSecretSchemes, ", "))
+}
+
+// validateSecrets checks that every name referenced from any task.Secrets
+// list is defined under the top-level `secrets:` map, and that every URI
+// declared there uses a supported scheme. Catching this at load time gives
+// users a clear error instead of one surfacing only when the offending task
+// happens to run.
+func validateSecrets(c *Config) error {
+	for taskName, task := range c.Tasks {
+		for _, name := range task.Secrets {
+			if _, ok := c.Secrets[name]; !ok {
+				return fmt.Errorf("task %q references unknown secret %q; declare it under top-level `secrets:`", taskName, name)
+			}
+		}
+	}
+	for name, uri := range c.Secrets {
+		if !secretSchemeKnown(uri) {
+			return fmt.Errorf("secret %q has unknown backend in %q (supported: %s)", name, uri, strings.Join(supportedSecretSchemes, ", "))
+		}
+	}
+	return nil
+}
+
+func secretSchemeKnown(uri string) bool {
+	for _, scheme := range supportedSecretSchemes {
+		if strings.HasPrefix(uri, scheme) {
+			return true
+		}
+	}
+	return false
+}

--- a/taskfile/secrets_test.go
+++ b/taskfile/secrets_test.go
@@ -1,0 +1,227 @@
+package taskfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- validation -------------------------------------------------------------
+
+func TestLoadWithIncludesRejectsTaskReferencingUnknownSecret(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+secrets:
+  KNOWN: op://vault/item/field
+tasks:
+  test:
+    secrets: [TYPO]
+    cmd: true
+`), 0o644))
+
+	_, err := LoadWithIncludes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"TYPO"`)
+	assert.Contains(t, err.Error(), `"test"`)
+}
+
+func TestLoadWithIncludesRejectsUnknownBackend(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+secrets:
+  X: vault://somewhere/else
+tasks:
+  test:
+    cmd: true
+`), 0o644))
+
+	_, err := LoadWithIncludes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown backend")
+	assert.Contains(t, err.Error(), "op://")
+}
+
+func TestLoadWithIncludesAcceptsValidSecretsBlock(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+secrets:
+  OPENAI_API_KEY: op://Team/docker-ai/OPENAI_API_KEY
+  ANTHROPIC_KEY:  op://Team/docker-ai/ANTHROPIC_API_KEY
+tasks:
+  test:
+    secrets: [OPENAI_API_KEY, ANTHROPIC_KEY]
+    cmd: true
+`), 0o644))
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "op://Team/docker-ai/OPENAI_API_KEY", tf.Secrets["OPENAI_API_KEY"])
+	assert.Equal(t, "op://Team/docker-ai/ANTHROPIC_API_KEY", tf.Secrets["ANTHROPIC_KEY"])
+	assert.Equal(t, StringList{"OPENAI_API_KEY", "ANTHROPIC_KEY"}, tf.Tasks["test"].Secrets)
+}
+
+func TestLoadWithIncludesMergesSecretsRootWins(t *testing.T) {
+	// Mirrors mergeVars / mergeSourcePresets precedence: child includes can
+	// declare secrets but the root file's declarations win on conflicts.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+includes: [cli]
+secrets:
+  SHARED: op://root/item/field
+`,
+		"cli/gogo.yaml": `version: "1"
+secrets:
+  SHARED:   op://child/item/field
+  CLI_ONLY: op://cli/item/field
+tasks:
+  build:
+    secrets: [SHARED, CLI_ONLY]
+    cmd: true
+`,
+	})
+
+	tf, err := LoadWithIncludes(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "op://root/item/field", tf.Secrets["SHARED"], "root preset wins")
+	assert.Equal(t, "op://cli/item/field", tf.Secrets["CLI_ONLY"], "child entry merged in")
+}
+
+// --- runtime ----------------------------------------------------------------
+
+func TestSecretsOpPassThroughTriggersOpRun(t *testing.T) {
+	// op:// is pass-through: the URI itself becomes the env value and
+	// hasOpSecrets triggers the op-run wrapper at exec time.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Secrets: map[string]string{
+			"OPENAI_API_KEY": "op://Team/docker-ai/OPENAI_API_KEY",
+		},
+		Tasks: map[string]Task{
+			"test": {
+				Secrets: StringList{"OPENAI_API_KEY"},
+				Cmds:    []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("test", ""))
+
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "op://Team/docker-ai/OPENAI_API_KEY",
+		envValue((*execs)[0].Env, "OPENAI_API_KEY"))
+	assert.True(t, (*execs)[0].UseOpRun, "op:// in resolved env must wrap exec in op run")
+}
+
+func TestSecretsBeatTaskEnvWithSameKey(t *testing.T) {
+	// If a task declares both `env: { K: dummy }` and `secrets: [K]`, the
+	// secrets resolution layer wins. Declaring a secret is a strong signal
+	// that K should come from the secrets backend, not a placeholder.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Secrets: map[string]string{
+			"OPENAI_API_KEY": "op://team/item/field",
+		},
+		Tasks: map[string]Task{
+			"test": {
+				Env:     map[string]string{"OPENAI_API_KEY": "DUMMY"},
+				Secrets: StringList{"OPENAI_API_KEY"},
+				Cmds:    []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("test", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "op://team/item/field", envValue((*execs)[0].Env, "OPENAI_API_KEY"))
+}
+
+func TestSecretsParentEnvPropagatesResolvedSecretsToSubTasks(t *testing.T) {
+	// The parent->child env propagation behaviour should carry resolved
+	// secrets down to sub-tasks just like any other env entry.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Secrets: map[string]string{
+			"OPENAI_API_KEY": "op://team/item/field",
+		},
+		Tasks: map[string]Task{
+			"parent": {
+				Secrets: StringList{"OPENAI_API_KEY"},
+				Cmds:    []Cmd{{Task: "child"}},
+			},
+			"child": {
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("parent", ""))
+
+	var child *Execution
+	for i := range *execs {
+		if (*execs)[i].Task == "child" {
+			child = &(*execs)[i]
+		}
+	}
+	require.NotNil(t, child)
+	assert.Equal(t, "op://team/item/field", envValue(child.Env, "OPENAI_API_KEY"))
+	assert.True(t, child.UseOpRun, "op:// flowed down to the child must keep wrapping in op run")
+}
+
+func TestSecretsTaskWithoutSecretsBlockUnaffected(t *testing.T) {
+	// Tasks that don't declare `secrets:` see no change in behaviour, even
+	// when a top-level secrets: block is defined. Per-task allow-list.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Secrets: map[string]string{
+			"OPENAI_API_KEY": "op://team/item/field",
+		},
+		Tasks: map[string]Task{
+			"clean": {Cmds: []Cmd{{Cmd: "rm -rf bin"}}},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("clean", ""))
+	require.Len(t, *execs, 1)
+	assert.Empty(t, envValue((*execs)[0].Env, "OPENAI_API_KEY"))
+	assert.False(t, (*execs)[0].UseOpRun)
+}
+
+func TestSecretsExistingOpInEnvStillTriggersOpRun(t *testing.T) {
+	// Backward compatibility: users who already have `env: { X: op://... }`
+	// without a top-level secrets: block must continue to work exactly as
+	// before. The hasOpSecrets path runs after the secrets layer, so any
+	// op:// in env (from any source) still wraps in op run.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"test": {
+				Env:  map[string]string{"OPENAI_API_KEY": "op://Team/docker-ai/OPENAI_API_KEY"},
+				Cmds: []Cmd{{Cmd: "true"}},
+			},
+		},
+	}
+	r := newTestRunner(t, tf, dir)
+	execs := captureExecs(r)
+
+	require.NoError(t, r.Run("test", ""))
+
+	require.Len(t, *execs, 1)
+	assert.True(t, (*execs)[0].UseOpRun)
+}

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -9,6 +9,7 @@ type Config struct {
 	Default    string                `yaml:"default"` // task to run when none is given on the CLI; replaces the convention of declaring a `default` task
 	Vars       map[string]Var        `yaml:"vars"`
 	Sources    map[string]StringList `yaml:"sources"` // named source presets, referenced from task.Sources by name
+	Secrets    map[string]string     `yaml:"secrets"` // named secret URIs (op://, aws-creds://, ...), referenced from task.Secrets
 	Tasks      map[string]Task       `yaml:"tasks"`
 	Dir        string                `yaml:"-"`
 	Interval   string                `yaml:"interval"`
@@ -24,6 +25,7 @@ type Task struct {
 	Dotenv        []string          `yaml:"dotenv"`
 	Env           map[string]string `yaml:"env"`
 	Vars          map[string]Var    `yaml:"vars"`
+	Secrets       StringList        `yaml:"secrets"` // names referencing entries in Config.Secrets
 	Sources       StringList        `yaml:"sources"`
 	Generates     StringList        `yaml:"generates"`
 	Aliases       StringList        `yaml:"aliases"`


### PR DESCRIPTION
## What

Adds a top-level `secrets:` block that declares each `op://` URI once and lets tasks opt in by name:

```yaml
secrets:
  OPENAI_API_KEY: op://Team AI Agent/docker-ai/OPENAI_API_KEY
  ANTHROPIC_KEY:  op://Team AI Agent/docker-ai/ANTHROPIC_API_KEY

tasks:
  test:
    secrets: [OPENAI_API_KEY]
    cmd: poetry run pytest

  dev:
    secrets: [OPENAI_API_KEY, ANTHROPIC_KEY]
    cmd: docker compose up --watch
```

Inline `env: { X: op://... }` continues to work unchanged.

## How it works

`Runner.resolveTaskSecrets` walks `task.Secrets`, looks each name up in `Config.Secrets`, and currently dispatches to a single backend:

| Scheme | Resolution |
|---|---|
| `op://...` | The URI itself is set as the env value, named after the secrets-map key. The existing `hasOpSecrets` / `op run` wrapper resolves it at exec time, so authentication (Touch ID, biometric, etc.) flows through `op` exactly as it does for inline `op://` references. |

The dispatch is structured so a new scheme is one new branch in `resolveSecretURI` plus a constant in `supportedSecretSchemes`; this PR ships only the `op://` case.

### Precedence

Secrets are layered as the **last** step of `buildEnv`, after `task.env`:

```
1. BaseEnv (OS env + global dotenv)
2. parentEnv (inherited from sub-task caller)
3. task.dotenv
4. task.vars
5. task.env
6. task.secrets   ← highest
```

So a task with both `env: { OPENAI_API_KEY: DUMMY }` and `secrets: [OPENAI_API_KEY]` gets the real secret, not the dummy. Declaring a secret is a stronger signal than declaring an env value.

The order means an `op://` URI injected by `secrets:` reaches `hasOpSecrets(env)` exactly the same way as inline `op://` in `task.env` — the legacy path keeps working without changes.

### Validation

Two load-time checks (after include merge):

```
task "test" references unknown secret "TYPO"; declare it under top-level `secrets:`
secret "X" has unknown backend in "vault://somewhere/else" (supported: op://)
```

Catches typos and stale names before any task runs.

### Includes

`secrets:` from included / flattened files merge into the root with the same precedence as `vars:` and `sources:` (root wins on conflict). Verified by `TestLoadWithIncludesMergesSecretsRootWins`.

## Changes

- **`taskfile/types.go`** — `Secrets map[string]string` on `Config`; `Secrets StringList` on `Task` (accepts both `secrets: A` shorthand and `secrets: [A, B]`).
- **`taskfile/secrets.go`** *(new)* — backend dispatch (`resolveSecretURI`), `op://` pass-through, `validateSecrets`.
- **`taskfile/env.go`** — `buildEnv` adds the secrets layer after `task.env`.
- **`taskfile/includes.go`** — `mergeSecrets` + validator wired into the load pipeline.
- **`taskfile/secrets_test.go`** *(new)* — 8 tests covering both validators, includes-merge precedence, op:// pass-through triggering `op run`, secrets-beat-task-env on key collision, parent→child env propagates resolved secrets, no-secrets task is unaffected, and legacy inline-`op://` still triggers `op run`.
- **Docs** — `docs/features/secrets/` rewritten around the centralised-block story with a backwards-compat note for inline `op://`; `task-file-syntax/` adds the new top-level + per-task fields; `AGENTS.md` notes how new backends plug in.

## Backward compatibility

- Inline `env: { X: op://... }` continues to work unchanged. `TestSecretsExistingOpInEnvStillTriggersOpRun` guards this.
- Public API unchanged.
- Existing `op://` URIs can be migrated to `secrets:` incrementally — both forms coexist in the same task.