### PR TITLE
Prefix matching for task names

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -37,11 +37,11 @@ func newTestApp(t *testing.T, dir string, cliArgs ...string) (*App, *bytes.Buffe
 }
 
 func TestIsInternalTask(t *testing.T) {
-	assert.False(t, isInternalTask("build"))
-	assert.True(t, isInternalTask("_hidden"))
-	assert.False(t, isInternalTask("cli:build"))
-	assert.True(t, isInternalTask("cli:_hidden"))
-	assert.True(t, isInternalTask("cli:utils:_fmt"))
+	assert.False(t, taskfile.IsInternalTask("build"))
+	assert.True(t, taskfile.IsInternalTask("_hidden"))
+	assert.False(t, taskfile.IsInternalTask("cli:build"))
+	assert.True(t, taskfile.IsInternalTask("cli:_hidden"))
+	assert.True(t, taskfile.IsInternalTask("cli:utils:_fmt"))
 }
 
 func TestVisibleTaskNames(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -205,20 +205,11 @@ func (a *App) loadConfig() (string, *taskfile.Config, error) {
 func visibleTaskNames(tf *taskfile.Config) []string {
 	var names []string
 	for _, name := range slices.Sorted(maps.Keys(tf.Tasks)) {
-		if !isInternalTask(name) {
+		if !taskfile.IsInternalTask(name) {
 			names = append(names, name)
 		}
 	}
 	return names
-}
-
-// isInternalTask reports whether a task name is internal (starts with _).
-// For namespaced tasks like "ns:_helper", the task part after the last colon is checked.
-func isInternalTask(name string) bool {
-	if i := strings.LastIndex(name, ":"); i >= 0 {
-		name = name[i+1:]
-	}
-	return strings.HasPrefix(name, "_")
 }
 
 func (a *App) printCompletionScript(shell string) error {

--- a/taskfile/task_resolution.go
+++ b/taskfile/task_resolution.go
@@ -3,36 +3,86 @@ package taskfile
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
-// resolveTaskName finds the actual task name, trying the exact name first,
-// then aliases, then prefixing with the namespace matching the current working directory.
+// resolveTask resolves user input — an exact name, alias, namespace shortcut,
+// or unique prefix — to a task name. Ambiguous prefixes are rejected so the
+// wrong task is never silently invoked.
+func (r *Runner) resolveTask(name string) (string, error) {
+	if resolved, ok := r.resolveTaskName(name); ok {
+		return resolved, nil
+	}
+	switch matches := r.prefixMatches(name); len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("task %q not found", name)
+	default:
+		return "", fmt.Errorf("task %q is ambiguous (matches: %s)", name, strings.Join(matches, ", "))
+	}
+}
+
+// resolveTaskName returns the canonical task name for input that matches a
+// task or alias exactly under any of the name's candidate interpretations
+// (literal, cwd-namespaced, self-prefix stripped). It does NOT perform
+// prefix matching — callers wanting that should use resolveTask.
 func (r *Runner) resolveTaskName(name string) (string, bool) {
-	if _, ok := r.tf.Tasks[name]; ok {
-		return name, true
-	}
-
-	if taskName, ok := r.aliases[name]; ok {
-		return taskName, true
-	}
-
-	if ns, ok := r.cwdNamespace(); ok {
-		if _, ok := r.tf.Tasks[ns+":"+name]; ok {
-			return ns + ":" + name, true
+	for _, cand := range r.nameCandidates(name) {
+		if _, ok := r.tf.Tasks[cand]; ok {
+			return cand, true
+		}
+		if taskName, ok := r.aliases[cand]; ok {
+			return taskName, true
 		}
 	}
+	return "", false
+}
 
-	// Try stripping a self-prefix that matches the task file root's basename.
-	// This lets "proxy:deploy-prod" work when running from a sub task file at
-	// proxy/ — the same name also works when the parent task file is the root.
-	if prefix, suffix, ok := strings.Cut(name, ":"); ok && prefix == filepath.Base(r.tf.Dir) {
-		if resolved, ok := r.resolveTaskName(suffix); ok {
-			return resolved, true
+// prefixMatches returns sorted task names that uniquely identify name as a
+// prefix, honouring the same candidate interpretations as resolveTaskName.
+// Internal tasks ('_'-prefixed local segment) are skipped so prefix matching
+// never lands on a private helper. An empty input matches nothing.
+func (r *Runner) prefixMatches(name string) []string {
+	if name == "" {
+		return nil
+	}
+	for _, cand := range r.nameCandidates(name) {
+		var out []string
+		for taskName := range r.tf.Tasks {
+			if strings.HasPrefix(taskName, cand) && !IsInternalTask(taskName) {
+				out = append(out, taskName)
+			}
+		}
+		if len(out) > 0 {
+			slices.Sort(out)
+			return out
 		}
 	}
+	return nil
+}
 
-	return name, false
+// nameCandidates lists the interpretations of name, in priority order, that
+// resolution should try. The literal name comes first; then — when cwd sits
+// inside an included namespace — the cwd-namespaced form; then, recursively,
+// the name with a self-prefix stripped (matching the task file root's
+// basename). Both exact and prefix matching walk this same list.
+func (r *Runner) nameCandidates(name string) []string {
+	base := filepath.Base(r.tf.Dir)
+	ns, hasNS := r.cwdNamespace()
+	var out []string
+	for cur := name; ; {
+		out = append(out, cur)
+		if hasNS {
+			out = append(out, ns+":"+cur)
+		}
+		prefix, suffix, hasColon := strings.Cut(cur, ":")
+		if !hasColon || prefix != base {
+			return out
+		}
+		cur = suffix
+	}
 }
 
 // cwdNamespace returns the most specific namespace whose directory contains
@@ -52,11 +102,13 @@ func (r *Runner) cwdNamespace() (string, bool) {
 	return bestNS, bestNS != ""
 }
 
-// resolveTask finds a task by name and returns its resolved name.
-func (r *Runner) resolveTask(name string) (string, error) {
-	resolved, ok := r.resolveTaskName(name)
-	if !ok {
-		return "", fmt.Errorf("task %q not found", name)
+// IsInternalTask reports whether a task name is internal (its local segment
+// starts with '_'). Only the part after the last colon is checked so
+// 'ns:_helper' is internal but 'ns:public' is not. Internal tasks are
+// hidden from --list, completion, and prefix matching.
+func IsInternalTask(name string) bool {
+	if i := strings.LastIndex(name, ":"); i >= 0 {
+		name = name[i+1:]
 	}
-	return resolved, nil
+	return strings.HasPrefix(name, "_")
 }

--- a/taskfile/task_resolution_test.go
+++ b/taskfile/task_resolution_test.go
@@ -1,0 +1,250 @@
+package taskfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makePrefixTF builds a Config with the given top-level task names. Each task
+// runs a no-op `cmd: true` so the runner can execute it without spawning a
+// shell (the fake shell runner intercepts).
+func makePrefixTF(dir string, names ...string) *Config {
+	tasks := make(map[string]Task, len(names))
+	for _, n := range names {
+		tasks[n] = Task{Cmds: []Cmd{{Cmd: "run-" + n}}}
+	}
+	return &Config{
+		Dir:        dir,
+		Tasks:      tasks,
+		DotenvVars: make(map[string]string),
+	}
+}
+
+func TestPrefixMatchUniqueResolvesToFullName(t *testing.T) {
+	// "gogo i" → "install" because "install" is the only task whose name
+	// starts with "i".
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build", "test")
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchLongerSubstring(t *testing.T) {
+	// "gogo inst" still resolves to "install".
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build")
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("inst", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchAmbiguousIsRejected(t *testing.T) {
+	// Two tasks start with "i": resolution must fail and *neither* should
+	// run. The error lists the candidates sorted for stable output.
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "info", "build")
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("i", "")
+	require.EqualError(t, err, `task "i" is ambiguous (matches: info, install)`)
+	assert.Empty(t, *execs)
+}
+
+func TestPrefixMatchExactWinsOverPrefix(t *testing.T) {
+	// When a task literally named "i" exists, prefix matching never kicks in
+	// even though "install" also starts with "i". Exact resolution is final.
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "i", "install")
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "i", (*execs)[0].Task)
+}
+
+func TestPrefixMatchSkipsInternalTasks(t *testing.T) {
+	// "_init" is an internal task and must not participate in prefix matching:
+	// "gogo i" still uniquely resolves to "install".
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "_init")
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchNoMatchReportsNotFound(t *testing.T) {
+	// An unmatchable prefix still reports the familiar "task not found"
+	// error so we don't change the error surface for genuine typos.
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "build", "test")
+
+	runner := newTestRunner(t, tf, dir)
+	captureExecs(runner)
+
+	err := runner.Run("xyz", "")
+	assert.EqualError(t, err, `task "xyz" not found`)
+}
+
+func TestPrefixMatchWithNamespacedInput(t *testing.T) {
+	// "gogo sub:i" → "sub:install" when "sub:install" is the only task that
+	// begins with "sub:i".
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"sub/.keep": ""})
+	subDir := filepath.Join(dir, "sub")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"sub:build":   {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-build"}}},
+			"install":     {Cmds: []Cmd{{Cmd: "run-install"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("sub:i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "sub:install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchAmbiguousWithinNamespace(t *testing.T) {
+	// Ambiguity check applies per-namespace too: "sub:i" matches both
+	// "sub:install" and "sub:info", so neither should run.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"sub/.keep": ""})
+	subDir := filepath.Join(dir, "sub")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"sub:info":    {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-info"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("sub:i", "")
+	require.EqualError(t, err, `task "sub:i" is ambiguous (matches: sub:info, sub:install)`)
+	assert.Empty(t, *execs)
+}
+
+func TestPrefixMatchFromCwdNamespace(t *testing.T) {
+	// When cwd is inside the "sub" include and the bare name has no
+	// top-level match, the cwd namespace is consulted before failing.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"sub/.keep": ""})
+	subDir := filepath.Join(dir, "sub")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"build":       {Cmds: []Cmd{{Cmd: "run-build"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, subDir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "sub:install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchPrefersTopLevelOverCwdNamespace(t *testing.T) {
+	// Top-level prefix matches take precedence over cwd-namespaced ones,
+	// mirroring how exact resolution works in resolveTaskName.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"sub/.keep": ""})
+	subDir := filepath.Join(dir, "sub")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"install":     {Cmds: []Cmd{{Cmd: "run-install"}}},
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, subDir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchSelfPrefix(t *testing.T) {
+	// When running a sub task file as its own root, "proxy:i" resolves to
+	// "install" the same way "proxy:install" does — the self-prefix is
+	// stripped before prefix matching.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"proxy/.keep": ""})
+	proxyDir := filepath.Join(dir, "proxy")
+
+	tf := &Config{
+		Dir: proxyDir,
+		Tasks: map[string]Task{
+			"install": {Cmds: []Cmd{{Cmd: "run-install"}}},
+			"build":   {Cmds: []Cmd{{Cmd: "run-build"}}},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, proxyDir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("proxy:i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchHonoursTopLevelDefault(t *testing.T) {
+	// The top-level `default:` field is validated at load time and must
+	// point at an exact task name — prefix matching is *not* applied there.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"gogo.yaml": `version: "1"
+default: ins
+tasks:
+  install:
+    cmd: true
+`,
+	})
+
+	_, err := LoadWithIncludes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"ins"`)
+}

--- a/taskfile/task_resolution_test.go
+++ b/taskfile/task_resolution_test.go
@@ -248,3 +248,58 @@ tasks:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"ins"`)
 }
+
+func TestPrefixMatchEmptyName(t *testing.T) {
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build")
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run("", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPrefixMatchColonOnly(t *testing.T) {
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build")
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run(":", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPrefixMatchTrailingColon(t *testing.T) {
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build")
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run("task:", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPrefixMatchWhenExactMatchIsAlsoPrefix(t *testing.T) {
+	// If we have tasks "i" and "install", and user types "i",
+	// exact match should win (return "i"), not prefix match (which would be ambiguous).
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "i", "install")
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "i", (*execs)[0].Task)
+}
+
+func TestIsInternalTaskEdgeCases(t *testing.T) {
+	assert.True(t, IsInternalTask("_"))
+	assert.True(t, IsInternalTask("_a"))
+	assert.True(t, IsInternalTask("ns:_"))
+	assert.True(t, IsInternalTask("ns:_a"))
+	assert.False(t, IsInternalTask("a_b"))
+	assert.False(t, IsInternalTask("ns:a_b"))
+	assert.False(t, IsInternalTask(""))
+	assert.False(t, IsInternalTask(":"))
+	assert.False(t, IsInternalTask("ns:"))
+}


### PR DESCRIPTION
Support invoking a task by any unique prefix of its name. `gogo i`, `gogo ins`, and `gogo inst` all run `install` when no other task name starts with the typed letters. If two or more task names share the prefix, resolution fails with an error and no task runs — so we never silently execute the wrong one.

Works the same way inside namespaces: `gogo sub:i` resolves to `sub:install`. When `cwd` sits inside an included namespace, bare names are also tried under that namespace, mirroring how exact resolution already works. Internal tasks (`_`-prefixed local segment) are excluded from prefix matching so private helpers never get auto-picked.

### Examples

```
$ gogo i        # → runs `install`
$ gogo inst     # → runs `install`
$ gogo sub:i    # → runs `sub:install`
$ gogo i        # when both `install` and `info` exist
task "i" is ambiguous (matches: info, install)
```

### Notes

- Exact names, aliases, and namespace shortcuts still win over prefix matching — behavior for anyone with an exact name only changes when their input doesn't match exactly.
- The top-level `default:` field still requires an exact name (validated at load time).
- Internal predicate `isInternalTask` previously duplicated in `main.go` is now exported as `taskfile.IsInternalTask` and used from both places.
- The candidate-name walk used by exact and prefix resolution is factored into a single `nameCandidates` helper to keep both paths consistent.