### PR TITLE
Segment-wise prefix matching for task names

### DIFF
--- a/taskfile/task_resolution.go
+++ b/taskfile/task_resolution.go
@@ -8,8 +8,8 @@ import (
 )
 
 // resolveTask resolves user input — an exact name, alias, namespace shortcut,
-// or unique prefix — to a task name. Ambiguous prefixes are rejected so the
-// wrong task is never silently invoked.
+// or a unique segment-wise prefix — to a task name. Ambiguous prefixes are
+// rejected so the wrong task is never silently invoked.
 func (r *Runner) resolveTask(name string) (string, error) {
 	if resolved, ok := r.resolveTaskName(name); ok {
 		return resolved, nil
@@ -40,18 +40,30 @@ func (r *Runner) resolveTaskName(name string) (string, bool) {
 	return "", false
 }
 
-// prefixMatches returns sorted task names that uniquely identify name as a
-// prefix, honouring the same candidate interpretations as resolveTaskName.
-// Internal tasks ('_'-prefixed local segment) are skipped so prefix matching
-// never lands on a private helper. An empty input matches nothing.
+// prefixMatches returns sorted task names that match name segment-by-segment:
+// each colon-separated piece of the input must be a non-empty prefix of the
+// corresponding piece of the task name, and the number of segments must
+// match. That lets 'sub:i' resolve to 'sub:install' and 's:i' to the same,
+// mirroring the way editors filter file paths. Candidate interpretations
+// from nameCandidates are tried in order so cwd-namespace and self-prefix
+// rules carry over. Internal tasks ('_'-prefixed local segment) are skipped
+// so prefix matching never lands on a private helper, and an empty input
+// (or any empty segment) matches nothing.
 func (r *Runner) prefixMatches(name string) []string {
 	if name == "" {
 		return nil
 	}
 	for _, cand := range r.nameCandidates(name) {
+		candSegs := strings.Split(cand, ":")
+		if slices.Contains(candSegs, "") {
+			continue
+		}
 		var out []string
 		for taskName := range r.tf.Tasks {
-			if strings.HasPrefix(taskName, cand) && !IsInternalTask(taskName) {
+			if IsInternalTask(taskName) {
+				continue
+			}
+			if segmentPrefixMatch(taskName, candSegs) {
 				out = append(out, taskName)
 			}
 		}
@@ -61,6 +73,23 @@ func (r *Runner) prefixMatches(name string) []string {
 		}
 	}
 	return nil
+}
+
+// segmentPrefixMatch reports whether each piece of candSegs is a prefix of
+// the corresponding colon-separated piece of taskName. The segment counts
+// must agree, so 'sub' on its own no longer matches 'sub:install' — the
+// user has to type something into every namespace level they want to span.
+func segmentPrefixMatch(taskName string, candSegs []string) bool {
+	taskSegs := strings.Split(taskName, ":")
+	if len(taskSegs) != len(candSegs) {
+		return false
+	}
+	for i, s := range candSegs {
+		if !strings.HasPrefix(taskSegs[i], s) {
+			return false
+		}
+	}
+	return true
 }
 
 // nameCandidates lists the interpretations of name, in priority order, that

--- a/taskfile/task_resolution_test.go
+++ b/taskfile/task_resolution_test.go
@@ -303,3 +303,134 @@ func TestIsInternalTaskEdgeCases(t *testing.T) {
 	assert.False(t, IsInternalTask(":"))
 	assert.False(t, IsInternalTask("ns:"))
 }
+
+func TestPrefixMatchAcrossNamespaceSegments(t *testing.T) {
+	// "gogo s:i" → "sub:install" — each colon-separated segment of the input
+	// is treated as a prefix of the corresponding task-name segment, the way
+	// editors filter file paths. "app:build" is excluded because its first
+	// segment doesn't start with "s".
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"sub/.keep": "",
+		"app/.keep": "",
+	})
+	subDir := filepath.Join(dir, "sub")
+	appDir := filepath.Join(dir, "app")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"sub:build":   {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-build"}}},
+			"app:build":   {Dir: appDir, Cmds: []Cmd{{Cmd: "run app-build"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub", appDir: "app"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("s:i", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "sub:install", (*execs)[0].Task)
+}
+
+func TestPrefixMatchAmbiguousAcrossNamespaceSegments(t *testing.T) {
+	// When the abbreviated namespace itself is ambiguous, every viable
+	// target is reported and nothing runs. "s:i" matches both "sub:install"
+	// and "shell:init", so resolution fails with both candidates listed.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"sub/.keep":   "",
+		"shell/.keep": "",
+	})
+	subDir := filepath.Join(dir, "sub")
+	shellDir := filepath.Join(dir, "shell")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"shell:init":  {Dir: shellDir, Cmds: []Cmd{{Cmd: "run shell-init"}}},
+			"sub:build":   {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-build"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub", shellDir: "shell"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("s:i", "")
+	require.EqualError(t, err, `task "s:i" is ambiguous (matches: shell:init, sub:install)`)
+	assert.Empty(t, *execs)
+}
+
+func TestPrefixMatchAcrossMultipleSegments(t *testing.T) {
+	// Segment-wise matching works at arbitrary depth: "a:b:c" →
+	// "app:build:compile" when that's the only triple that lines up.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"app/build/.keep": "",
+		"app/test/.keep":  "",
+	})
+	appBuildDir := filepath.Join(dir, "app", "build")
+	appTestDir := filepath.Join(dir, "app", "test")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"app:build:compile": {Dir: appBuildDir, Cmds: []Cmd{{Cmd: "compile"}}},
+			"app:test:run":      {Dir: appTestDir, Cmds: []Cmd{{Cmd: "test-run"}}},
+		},
+		Namespaces: map[string]string{appBuildDir: "app:build", appTestDir: "app:test"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	require.NoError(t, runner.Run("a:b:c", ""))
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "app:build:compile", (*execs)[0].Task)
+}
+
+func TestPrefixMatchSegmentCountMustAgree(t *testing.T) {
+	// A bare "sub" no longer matches "sub:install" — segment-wise matching
+	// requires the user to type something for every namespace level they
+	// want to span. Mistyping the namespace as if it were a flat task name
+	// now fails fast rather than ambiguously matching every task under it.
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"sub/.keep": ""})
+	subDir := filepath.Join(dir, "sub")
+
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"sub:install": {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-install"}}},
+			"sub:build":   {Dir: subDir, Cmds: []Cmd{{Cmd: "run sub-build"}}},
+		},
+		Namespaces: map[string]string{subDir: "sub"},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("sub", "")
+	require.EqualError(t, err, `task "sub" not found`)
+	assert.Empty(t, *execs)
+}
+
+func TestPrefixMatchLeadingColon(t *testing.T) {
+	// A leading colon should not match anything — it produces an empty
+	// first segment which can never prefix-match a real task name.
+	dir := t.TempDir()
+	tf := makePrefixTF(dir, "install", "build")
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run(":install", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
Follow-up to #9, addressing @rumpl's feedback: let `gogo s:i` resolve to `sub:install` the same way editors (e.g. VS Code's file picker) match path segments.

### What changed

Prefix matching now splits both the user input and each task name on `:` and requires each input segment to be a non-empty prefix of the corresponding task-name segment. Segment counts must agree.

### Examples

```
$ gogo s:i        # → runs sub:install
$ gogo a:b:c      # → runs app:build:compile
$ gogo s:i        # when both sub:install and shell:init exist
task "s:i" is ambiguous (matches: shell:init, sub:install)
```

### Notes

- Existing precedence is preserved: exact > alias > segment-wise prefix; cwd-namespace and self-prefix candidates from `nameCandidates` still apply.
- Internal tasks (`_`-prefixed local segment) remain excluded.
- One small behavior change worth flagging: a bare `sub` no longer ambiguously matches every task under `sub:` — segment counts must agree, so `gogo sub` now fails fast with "not found" instead of listing every `sub:*` task. The `TestPrefixMatchSegmentCountMustAgree` test documents this.
- Empty segments (leading/trailing/double colons) are rejected so an empty piece never matches everything.