### PR TITLE
Add defer, ignore_error, prompt and status task features

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ gogo -n build
 A quick tour. Each item links to the canonical docs page.
 
 - **Incremental builds** — SHA-256 source checksums or `generates:` timestamp comparison ([Sources & Checksums](https://dgageot.github.io/gogo/features/sources-checksums/))
+- **Status checks** — `status:` commands probe the desired end state and skip the task when it already exists
 - **Source presets** — reuse named glob lists; built-in `go` / `go-vendored`, or define your own ([Sources & Checksums](https://dgageot.github.io/gogo/features/sources-checksums/#presets))
 - **Watch mode** — polls sources at a configurable `interval:` and re-runs ([Watch Mode](https://dgageot.github.io/gogo/features/watch-mode/))
 - **Concurrent dependencies** with deduplication ([Dependencies](https://dgageot.github.io/gogo/features/dependencies/))

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A quick tour. Each item links to the canonical docs page.
 - **1Password secrets** via `op://` references and a top-level `secrets:` block ([Secrets](https://dgageot.github.io/gogo/features/secrets/))
 - **Preconditions & requires** to guard tasks before they run ([Preconditions](https://dgageot.github.io/gogo/features/preconditions/))
 - **Deferred cleanup** — `defer:` cmds run after the task, in reverse order, even on failure
+- **Error tolerance** — `ignore_error: true` lets a task continue past a failing cmd
 - **Platform filtering** to restrict tasks to specific OS/arch
 - **Includes & flatten** to split task files across subdirectories ([Includes](https://dgageot.github.io/gogo/features/includes/))
 - **Dry run** mode (`gogo -n`) to preview the plan ([CLI Reference](https://dgageot.github.io/gogo/features/cli/))

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A quick tour. Each item links to the canonical docs page.
 - **Preconditions & requires** to guard tasks before they run ([Preconditions](https://dgageot.github.io/gogo/features/preconditions/))
 - **Deferred cleanup** — `defer:` cmds run after the task, in reverse order, even on failure
 - **Error tolerance** — `ignore_error: true` lets a task continue past a failing cmd
+- **Prompts** — `prompt:` asks for confirmation before destructive tasks; `--yes` auto-confirms
 - **Platform filtering** to restrict tasks to specific OS/arch
 - **Includes & flatten** to split task files across subdirectories ([Includes](https://dgageot.github.io/gogo/features/includes/))
 - **Dry run** mode (`gogo -n`) to preview the plan ([CLI Reference](https://dgageot.github.io/gogo/features/cli/))

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A quick tour. Each item links to the canonical docs page.
 - **Dotenv** — global and per-task, with deterministic precedence ([Dotenv](https://dgageot.github.io/gogo/features/dotenv/))
 - **1Password secrets** via `op://` references and a top-level `secrets:` block ([Secrets](https://dgageot.github.io/gogo/features/secrets/))
 - **Preconditions & requires** to guard tasks before they run ([Preconditions](https://dgageot.github.io/gogo/features/preconditions/))
+- **Deferred cleanup** — `defer:` cmds run after the task, in reverse order, even on failure
 - **Platform filtering** to restrict tasks to specific OS/arch
 - **Includes & flatten** to split task files across subdirectories ([Includes](https://dgageot.github.io/gogo/features/includes/))
 - **Dry run** mode (`gogo -n`) to preview the plan ([CLI Reference](https://dgageot.github.io/gogo/features/cli/))

--- a/app_test.go
+++ b/app_test.go
@@ -103,6 +103,38 @@ func TestAppCompletionUnsupportedShell(t *testing.T) {
 	assert.EqualError(t, err, "unsupported shell: pwsh (valid: bash, zsh, fish)")
 }
 
+func TestAppYesFlagAutoConfirmsPrompt(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+tasks:
+  deploy:
+    prompt: Deploy to production?
+    cmd: true
+`)
+
+	app, _, stderr := newTestApp(t, dir, "--yes", "deploy")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.NotContains(t, stderr.String(), "[y/N]")
+}
+
+func TestAppPromptReadsStdin(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+tasks:
+  deploy:
+    prompt: Deploy to production?
+    cmd: true
+`)
+
+	app, _, stderr := newTestApp(t, dir, "deploy")
+	app.Stdin = strings.NewReader("n\n")
+
+	err := app.Run(t.Context())
+	require.ErrorContains(t, err, `task "deploy": prompt declined`)
+	assert.Contains(t, stderr.String(), "Deploy to production? [y/N]:")
+}
+
 func TestAppListShowsDescriptionsAndAliases(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -23,6 +23,7 @@ tasks, so `gogo clean install` runs `clean`, then `install` (including
 | `-w`, `--watch` | Watch sources and re-run on changes |
 | `-f`, `--force` | Ignore `sources` / `generates` and always run the task |
 | `-n`, `--dry` | Print commands without executing them |
+| `-y`, `--yes` | Auto-confirm task prompts (see [Prompts](../task-file-syntax/#prompts)) |
 | `--completion <shell>` | Print a shell completion script (`bash`, `zsh`, or `fish`) |
 | `--help` | Show help |
 

--- a/docs/features/sources-checksums/index.md
+++ b/docs/features/sources-checksums/index.md
@@ -39,6 +39,39 @@ tasks:
 
 This avoids checksum storage and matches traditional `make`-style incremental builds.
 
+## Status Mode (`status:`)
+
+When file fingerprints can't answer "is this already done?", give the task `status:` commands — shell probes of the desired end state. The task is skipped when **every** status command exits 0:
+
+```yaml
+tasks:
+  create-bucket:
+    status:
+      - aws s3api head-bucket --bucket my-app-artifacts
+    cmd: aws s3 mb s3://my-app-artifacts
+
+  install-tools:
+    status:
+      - which golangci-lint
+      - which goimports
+    cmds:
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - go install golang.org/x/tools/cmd/goimports@latest
+```
+
+This suits idempotent operations — creating cloud resources, installing tools, running database migrations — where the world, not a file tree, holds the answer.
+
+Semantics:
+
+- A single command can be written as a plain string: `status: which aws`.
+- The first failing command short-circuits — one "not done" answer is enough to run the task.
+- **With `sources:` too, both must agree**: changed sources force a run regardless of status (the probes aren't even run), and a failing status forces a run even when sources are unchanged.
+- `--force` bypasses status checks like every other up-to-date mechanism.
+- Status commands run with the task's full environment, including [`op://` secret](../secrets/) resolution — same as preconditions.
+- Under `--dry`, status probes still run (they're read-only checks) so the printed plan reflects what a real run would skip.
+
+Not to be confused with [preconditions](../preconditions/), which invert the meaning: a failing precondition **aborts with an error** ("you may not run"), while a failing status command simply means the task needs to run.
+
 ## Glob Patterns
 
 Non-recursive patterns are matched with Go's [`filepath.Glob`](https://pkg.go.dev/path/filepath#Glob), which supports `*`, `?`, and `[…]` character classes within a single path segment:

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -37,6 +37,7 @@ Each task supports the following fields:
 | `secrets` | list or string | Names referencing entries in the top-level `secrets:` map (see [Secrets](../secrets/)) |
 | `sources` | list or string | Glob patterns for incremental builds and watch mode. A bare name resolves to a [source preset](../sources-checksums/#presets) (e.g. `sources: go`) |
 | `generates` | list | Output file patterns for timestamp-based incremental builds |
+| `status` | list or string | Shell commands probing the task's end state; all exiting 0 marks it up to date (see [Sources & Checksums](../sources-checksums/#status-mode-status)) |
 | `aliases` | list | Alternative names for the task |
 | `platforms` | list | Restrict task to specific OS/arch (e.g. `linux`, `darwin/arm64`) |
 | `requires` | map | Required variables (`vars`) and environment variables (`env`) |

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -117,6 +117,31 @@ tasks:
 
 The child's own `env` block (or a per-call `vars:` override) wins per key. See [Variables](../variables/#parent-to-child-env-propagation) for the full precedence rules.
 
+## Deferred Cleanup
+
+A command entry can use `defer:` instead of `cmd:` to register a cleanup command. Deferred commands run after the task's other commands finish — **even when one of them fails** — making them the right place for teardown:
+
+```yaml
+tasks:
+  test:
+    cmds:
+      - docker compose up -d
+      - defer: docker compose down
+      - go test ./...
+```
+
+Here `docker compose down` runs whether `go test` passes or fails.
+
+Deferred commands follow Go's `defer` semantics:
+
+- They run in **reverse registration order** (last registered, first run).
+- Only defers registered **before** a failure run — a `defer:` listed after a failing command never registered, so it is skipped.
+- A deferred command's own failure is logged as a warning but does **not** fail the task: cleanup must not mask the task's real result, and later defers still run.
+- Variables (`{{ "{{" }}.VAR}}`) are expanded in deferred commands like in regular ones.
+- Under `--dry`, deferred commands are printed but not executed.
+
+`defer:` only accepts a shell command string — `defer: { task: cleanup }` is not supported.
+
 ## Task Descriptions
 
 Comments above a task key are used as the task description, shown by `gogo -l`:

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -41,6 +41,7 @@ Each task supports the following fields:
 | `platforms` | list | Restrict task to specific OS/arch (e.g. `linux`, `darwin/arm64`) |
 | `requires` | map | Required variables (`vars`) and environment variables (`env`) |
 | `preconditions` | list | Shell commands that must succeed before the task runs |
+| `prompt` | string | Confirmation question shown before the task runs; declining aborts (see [Prompts](#prompts)) |
 | `silent` | bool | When `true`, suppress the `[task] cmd` log line for each command |
 
 ## Default Task
@@ -156,6 +157,32 @@ tasks:
 ```
 
 `ignore_error` is scoped to the individual command — a later command without it still fails the task. It only applies to shell commands: it is not honored on `task:` sub-calls (a failing child task always propagates) or on `defer:` entries (whose failures are already ignored).
+
+## Prompts
+
+Guard destructive tasks with a `prompt:` — a confirmation question asked before the task (and its dependencies) runs:
+
+```yaml
+tasks:
+  deploy:
+    prompt: Deploy to production?
+    deps: [build]
+    cmd: ./deploy.sh
+```
+
+```
+$ gogo deploy
+[deploy] Deploy to production? [y/N]:
+```
+
+Only `y` or `yes` (case-insensitive) confirms. Anything else — including pressing Enter, EOF, or a closed stdin — declines and aborts with `task "deploy": prompt declined`, leaving the system untouched: dependencies haven't run either.
+
+Two cases skip the question:
+
+- `gogo --yes` (or `-y`) auto-confirms every prompt, keeping guarded tasks scriptable in CI.
+- `gogo --dry` skips it because nothing will execute anyway.
+
+The prompt is asked before variables and environment are resolved, so the message is shown literally — `{{ "{{" }}.VAR}}` references are not expanded.
 
 ## Task Descriptions
 

--- a/docs/features/task-file-syntax/index.md
+++ b/docs/features/task-file-syntax/index.md
@@ -142,6 +142,21 @@ Deferred commands follow Go's `defer` semantics:
 
 `defer:` only accepts a shell command string — `defer: { task: cleanup }` is not supported.
 
+## Ignoring Command Failures
+
+By default, a failing command aborts the task. Set `ignore_error: true` on a command to log the failure as a warning and continue with the next command:
+
+```yaml
+tasks:
+  clean:
+    cmds:
+      - cmd: rm bin/app        # may not exist — that's fine
+        ignore_error: true
+      - echo cleaned
+```
+
+`ignore_error` is scoped to the individual command — a later command without it still fails the task. It only applies to shell commands: it is not honored on `task:` sub-calls (a failing child task always propagates) or on `defer:` entries (whose failures are already ignored).
+
 ## Task Descriptions
 
 Comments above a task key are used as the task description, shown by `gogo -l`:

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ type args struct {
 	Watch      bool     `arg:"-w,--watch" help:"watch sources and re-run on changes"`
 	Force      bool     `arg:"-f,--force" help:"ignore sources and generates (always run)"`
 	DryRun     bool     `arg:"-n,--dry" help:"print commands without executing them"`
+	Yes        bool     `arg:"-y,--yes" help:"auto-confirm task prompts"`
 	Completion string   `arg:"--completion" help:"print shell completion script (bash|zsh|fish)"`
 	Complete   bool     `arg:"--complete,hidden"`
 	Tasks      []string `arg:"positional" help:"tasks to run in sequence"`
@@ -41,6 +42,7 @@ func (args) Description() string {
 // without touching os.Args, process stdio, or the real cwd.
 type App struct {
 	Args   []string               // command-line args, without program name
+	Stdin  io.Reader              // interactive input (task prompts); nil means no input
 	Stdout io.Writer              // user-visible output (help, --list, completion scripts)
 	Stderr io.Writer              // error messages
 	Getwd  func() (string, error) // working directory lookup
@@ -49,6 +51,7 @@ type App struct {
 func main() {
 	app := &App{
 		Args:   os.Args[1:],
+		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Getwd:  os.Getwd,
@@ -97,10 +100,16 @@ func (a *App) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Stdin is wired only when provided so embedders that leave it nil keep
+	// the runner's default (the process stdin).
+	if a.Stdin != nil {
+		runner.IO.Stdin = a.Stdin
+	}
 	runner.IO.Stdout = a.Stdout
 	runner.IO.Stderr = a.Stderr
 	runner.DryRun = parsed.DryRun
 	runner.Force = parsed.Force
+	runner.AssumeYes = parsed.Yes
 
 	taskNames := defaultTaskNames(parsed.Tasks, tf)
 

--- a/taskfile/defer_test.go
+++ b/taskfile/defer_test.go
@@ -1,0 +1,153 @@
+package taskfile
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeferRunsAfterCmdsInReverseOrder(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Defer: "echo cleanup1"},
+					{Cmd: "echo step1"},
+					{Defer: "echo cleanup2"},
+					{Cmd: "echo step2"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("build", "")
+	require.NoError(t, err)
+
+	var cmds []string
+	for _, e := range *execs {
+		cmds = append(cmds, e.Command)
+	}
+	assert.Equal(t, []string{"echo step1", "echo step2", "echo cleanup2", "echo cleanup1"}, cmds)
+}
+
+func TestDeferRunsWhenCmdFails(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Defer: "echo cleanup"},
+					{Cmd: "echo failing"},
+					{Defer: "echo never-registered"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	boom := errors.New("boom")
+	var execs []string
+	runner.ShellRunner = &fakeShellRunner{
+		runFunc: func(req ShellCommand) error {
+			execs = append(execs, req.Command)
+			if req.Command == "echo failing" {
+				return boom
+			}
+			return nil
+		},
+	}
+
+	err := runner.Run("build", "")
+	require.ErrorIs(t, err, boom)
+	// The defer registered before the failure runs; the one after doesn't.
+	assert.Equal(t, []string{"echo failing", "echo cleanup"}, execs)
+}
+
+func TestDeferFailureDoesNotFailTask(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Defer: "exit 1"},
+					{Cmd: "echo step"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	runner.ShellRunner = &fakeShellRunner{
+		runFunc: func(req ShellCommand) error {
+			if req.Command == "exit 1" {
+				return errors.New("cleanup failed")
+			}
+			return nil
+		},
+	}
+
+	err := runner.Run("build", "")
+	assert.NoError(t, err, "a failed deferred command must not fail the task")
+}
+
+func TestDeferExpandsVars(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Vars: map[string]Var{"TMP": {Value: "scratch"}},
+				Cmds: []Cmd{
+					{Defer: "rm -rf {{.TMP}}"},
+					{Cmd: "echo step"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("build", "")
+	require.NoError(t, err)
+
+	require.Len(t, *execs, 2)
+	assert.Equal(t, "rm -rf scratch", (*execs)[1].Command)
+}
+
+func TestDeferDryRunDoesNotExecute(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Defer: "echo cleanup"},
+					{Cmd: "echo step"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	runner.DryRun = true
+	execs := captureExecs(runner)
+
+	err := runner.Run("build", "")
+	require.NoError(t, err)
+	assert.Empty(t, *execs)
+}

--- a/taskfile/ignore_error_test.go
+++ b/taskfile/ignore_error_test.go
@@ -1,0 +1,73 @@
+package taskfile
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreErrorContinuesExecution(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Cmd: "echo step1"},
+					{Cmd: "echo failing", IgnoreError: true},
+					{Cmd: "echo step3"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	var execs []string
+	runner.ShellRunner = &fakeShellRunner{
+		runFunc: func(req ShellCommand) error {
+			execs = append(execs, req.Command)
+			if req.Command == "echo failing" {
+				return errors.New("boom")
+			}
+			return nil
+		},
+	}
+
+	err := runner.Run("build", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"echo step1", "echo failing", "echo step3"}, execs)
+}
+
+func TestIgnoreErrorIsPerCmd(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Cmds: []Cmd{
+					{Cmd: "echo failing", IgnoreError: true},
+					{Cmd: "echo also-failing"},
+					{Cmd: "echo never-runs"},
+				},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	boom := errors.New("boom")
+	var execs []string
+	runner.ShellRunner = &fakeShellRunner{
+		runFunc: func(req ShellCommand) error {
+			execs = append(execs, req.Command)
+			return boom
+		},
+	}
+
+	err := runner.Run("build", "")
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, []string{"echo failing", "echo also-failing"}, execs)
+}

--- a/taskfile/parse_test.go
+++ b/taskfile/parse_test.go
@@ -350,6 +350,27 @@ tasks:
 	assert.Equal(t, "go test ./...", task.Cmds[2].Cmd)
 }
 
+func TestParseIgnoreError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+tasks:
+  clean:
+    cmds:
+      - cmd: rm bin/app
+        ignore_error: true
+      - echo done
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	task := tf.Tasks["clean"]
+	require.Len(t, task.Cmds, 2)
+	assert.Equal(t, "rm bin/app", task.Cmds[0].Cmd)
+	assert.True(t, task.Cmds[0].IgnoreError)
+	assert.False(t, task.Cmds[1].IgnoreError, "ignore_error defaults to false")
+}
+
 func TestParseSilentField(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"

--- a/taskfile/parse_test.go
+++ b/taskfile/parse_test.go
@@ -389,6 +389,27 @@ tasks:
 	assert.Empty(t, tf.Tasks["build"].Prompt)
 }
 
+func TestParseStatusField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+tasks:
+  create-bucket:
+    status:
+      - aws s3api head-bucket --bucket artifacts
+      - which aws
+    cmd: aws s3 mb s3://artifacts
+  install:
+    status: which golangci-lint
+    cmd: go install golangci-lint
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, StringList{"aws s3api head-bucket --bucket artifacts", "which aws"}, tf.Tasks["create-bucket"].Status)
+	assert.Equal(t, StringList{"which golangci-lint"}, tf.Tasks["install"].Status, "single string form")
+}
+
 func TestParseSilentField(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"

--- a/taskfile/parse_test.go
+++ b/taskfile/parse_test.go
@@ -329,6 +329,27 @@ tasks:
 	assert.Empty(t, task.Preconditions[1].Msg)
 }
 
+func TestParseDeferCmd(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+tasks:
+  test:
+    cmds:
+      - docker compose up -d
+      - defer: docker compose down
+      - go test ./...
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	task := tf.Tasks["test"]
+	require.Len(t, task.Cmds, 3)
+	assert.Equal(t, "docker compose up -d", task.Cmds[0].Cmd)
+	assert.Equal(t, "docker compose down", task.Cmds[1].Defer)
+	assert.Equal(t, "go test ./...", task.Cmds[2].Cmd)
+}
+
 func TestParseSilentField(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"

--- a/taskfile/parse_test.go
+++ b/taskfile/parse_test.go
@@ -371,6 +371,24 @@ tasks:
 	assert.False(t, task.Cmds[1].IgnoreError, "ignore_error defaults to false")
 }
 
+func TestParsePromptField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"
+tasks:
+  deploy:
+    prompt: Deploy to production?
+    cmd: echo deploying
+  build:
+    cmd: go build
+`), 0o644))
+
+	tf, err := Parse(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Deploy to production?", tf.Tasks["deploy"].Prompt)
+	assert.Empty(t, tf.Tasks["build"].Prompt)
+}
+
 func TestParseSilentField(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "gogo.yaml"), []byte(`version: "1"

--- a/taskfile/prompt.go
+++ b/taskfile/prompt.go
@@ -1,0 +1,53 @@
+package taskfile
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// confirmPrompt asks the user to confirm a task guarded by `prompt:` and
+// returns an error when the answer is anything but yes. Dry runs skip the
+// question because nothing will execute anyway, and --yes (AssumeYes)
+// auto-confirms so guarded tasks stay scriptable in CI. EOF or an unreadable
+// stdin counts as a decline — a non-interactive run must never assume
+// consent for a task its author chose to guard.
+func (r *Runner) confirmPrompt(taskName, prompt string) error {
+	if r.DryRun || r.AssumeYes {
+		return nil
+	}
+
+	fmt.Fprintf(r.IO.Stderr, "%s[%s]%s %s [y/N]: ", colorYellow, taskName, colorReset, prompt)
+
+	declined := fmt.Errorf("task %q: prompt declined", taskName)
+	if r.IO.Stdin == nil {
+		return declined
+	}
+	switch strings.ToLower(strings.TrimSpace(readAnswer(r.IO.Stdin))) {
+	case "y", "yes":
+		return nil
+	default:
+		return declined
+	}
+}
+
+// readAnswer reads one line, one byte at a time, so nothing past the newline
+// is buffered away — with piped input (`printf "y\ninput" | gogo deploy`)
+// everything after the answer still belongs to the task's own stdin.
+func readAnswer(r io.Reader) string {
+	var line []byte
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				break
+			}
+			line = append(line, buf[0])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return string(line)
+}

--- a/taskfile/prompt_test.go
+++ b/taskfile/prompt_test.go
@@ -1,0 +1,123 @@
+package taskfile
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// promptConfig returns a config with a guarded "deploy" task and its "build" dep.
+func promptConfig(dir string) *Config {
+	return &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"deploy": {
+				Prompt: "Deploy to production?",
+				Deps:   []Dep{{Task: "build"}},
+				Cmds:   []Cmd{{Cmd: "echo deploying"}},
+			},
+			"build": {
+				Cmds: []Cmd{{Cmd: "echo building"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+}
+
+func TestPromptYesRunsTask(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.IO.Stdin = strings.NewReader("y\n")
+	var stderr strings.Builder
+	runner.IO.Stderr = &stderr
+	execs := captureExecs(runner)
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Deploy to production? [y/N]:")
+	require.Len(t, *execs, 2)
+}
+
+func TestPromptDoesNotConsumeTaskStdin(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	stdin := strings.NewReader("y\npiped input for the task")
+	runner.IO.Stdin = stdin
+	runner.IO.Stderr = &strings.Builder{}
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	rest, err := io.ReadAll(stdin)
+	require.NoError(t, err)
+	assert.Equal(t, "piped input for the task", string(rest),
+		"the prompt must read only up to the newline; the rest belongs to the task")
+}
+
+func TestPromptDeclineAbortsBeforeDeps(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.IO.Stdin = strings.NewReader("n\n")
+	runner.IO.Stderr = &strings.Builder{}
+	execs := captureExecs(runner)
+
+	err := runner.Run("deploy", "")
+	require.ErrorContains(t, err, `task "deploy": prompt declined`)
+	assert.Empty(t, *execs, "declining must leave deps and cmds unexecuted")
+}
+
+func TestPromptEOFDeclines(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.IO.Stdin = strings.NewReader("")
+	runner.IO.Stderr = &strings.Builder{}
+
+	err := runner.Run("deploy", "")
+	require.ErrorContains(t, err, "prompt declined")
+}
+
+func TestPromptNilStdinDeclines(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.IO.Stdin = nil
+	runner.IO.Stderr = &strings.Builder{}
+
+	err := runner.Run("deploy", "")
+	require.ErrorContains(t, err, "prompt declined")
+}
+
+func TestPromptAssumeYesSkipsQuestion(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.AssumeYes = true
+	runner.IO.Stdin = nil // must not be read
+	var stderr strings.Builder
+	runner.IO.Stderr = &stderr
+	execs := captureExecs(runner)
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	assert.NotContains(t, stderr.String(), "[y/N]")
+	require.Len(t, *execs, 2)
+}
+
+func TestPromptDryRunSkipsQuestion(t *testing.T) {
+	dir := t.TempDir()
+	runner := newTestRunner(t, promptConfig(dir), dir)
+	runner.DryRun = true
+	runner.IO.Stdin = nil // must not be read
+	var stderr strings.Builder
+	runner.IO.Stderr = &stderr
+	execs := captureExecs(runner)
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	assert.NotContains(t, stderr.String(), "[y/N]")
+	assert.Empty(t, *execs)
+}

--- a/taskfile/runner.go
+++ b/taskfile/runner.go
@@ -41,6 +41,7 @@ type Runner struct {
 	aliases     map[string]string // alias -> task name
 	DryRun      bool              // if true, print commands without executing them
 	Force       bool              // if true, ignore sources and generates (always run)
+	AssumeYes   bool              // if true, task prompts are auto-confirmed (--yes)
 	ShellRunner ShellRunner       // replaceable shell executor (defaults to real exec)
 	IO          RunnerIO          // process streams used for logs and command stdio
 	runs        sync.Map          // resolved task name -> *taskRun

--- a/taskfile/shell.go
+++ b/taskfile/shell.go
@@ -16,6 +16,7 @@ type ShellCommandKind string
 const (
 	ShellCommandTask         ShellCommandKind = "task"
 	ShellCommandPrecondition ShellCommandKind = "precondition"
+	ShellCommandStatus       ShellCommandKind = "status"
 	ShellCommandVar          ShellCommandKind = "var"
 )
 

--- a/taskfile/status_test.go
+++ b/taskfile/status_test.go
@@ -1,0 +1,230 @@
+package taskfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusRuns returns the status-kind shell commands recorded by the fake runner.
+func statusRuns(t *testing.T, r *Runner) []ShellCommand {
+	t.Helper()
+	shell, ok := r.ShellRunner.(*fakeShellRunner)
+	require.True(t, ok)
+
+	var status []ShellCommand
+	for _, req := range shell.runsSnapshot() {
+		if req.Kind == ShellCommandStatus {
+			status = append(status, req)
+		}
+	}
+	return status
+}
+
+func TestStatusPassingSkipsTask(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"create-bucket": {
+				Status: StringList{"true"},
+				Cmds:   []Cmd{{Cmd: "echo creating"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("create-bucket", "")
+	require.NoError(t, err)
+	assert.Empty(t, *execs, "all status commands passed, the task is up to date")
+}
+
+func TestStatusFailingRunsTask(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"create-bucket": {
+				Status: StringList{"false"},
+				Cmds:   []Cmd{{Cmd: "echo creating"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("create-bucket", "")
+	require.NoError(t, err)
+	require.Len(t, *execs, 1)
+	assert.Equal(t, "echo creating", (*execs)[0].Command)
+}
+
+func TestStatusStopsAtFirstFailure(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"install": {
+				Status: StringList{"false", "true"},
+				Cmds:   []Cmd{{Cmd: "echo installing"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	execs := captureExecs(runner)
+
+	err := runner.Run("install", "")
+	require.NoError(t, err)
+	assert.Len(t, *execs, 1, "a failing status command means the task runs")
+
+	status := statusRuns(t, runner)
+	require.Len(t, status, 1, "the first failing status command short-circuits")
+	assert.Equal(t, "false", status[0].Command)
+}
+
+func TestStatusForceBypassesCheck(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"create-bucket": {
+				Status: StringList{"true"},
+				Cmds:   []Cmd{{Cmd: "echo creating"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	runner.Force = true
+	execs := captureExecs(runner)
+
+	err := runner.Run("create-bucket", "")
+	require.NoError(t, err)
+	assert.Len(t, *execs, 1, "--force runs the task regardless of status")
+	assert.Empty(t, statusRuns(t, runner), "--force doesn't even probe")
+}
+
+func TestStatusAndSourcesBothMustAgree(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"main.go": "package main"})
+
+	statusCmd := "true"
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"build": {
+				Sources: StringList{"*.go"},
+				Status:  StringList{"check-state"},
+				Cmds:    []Cmd{{Cmd: "echo building"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	shell, ok := runner.ShellRunner.(*fakeShellRunner)
+	require.True(t, ok)
+	shell.runFunc = func(req ShellCommand) error {
+		if req.Command == "check-state" && statusCmd == "false" {
+			return assert.AnError
+		}
+		return nil
+	}
+	execs := captureExecs(runner)
+
+	// First run: no stored checksum, sources are stale — runs without probing status.
+	require.NoError(t, runner.Run("build", ""))
+	require.Len(t, *execs, 1)
+	assert.Empty(t, statusRuns(t, runner), "stale sources already force a run")
+
+	// Second run: sources up to date and status passes — skipped.
+	runner.ResetRan()
+	require.NoError(t, runner.Run("build", ""))
+	assert.Len(t, *execs, 1)
+
+	// Third run: sources still up to date but status fails — runs.
+	statusCmd = "false"
+	runner.ResetRan()
+	require.NoError(t, runner.Run("build", ""))
+	assert.Len(t, *execs, 2, "a failing status overrides fresh sources")
+}
+
+func TestStatusUsesOpRunForSecrets(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"deploy": {
+				Env:    map[string]string{"TOKEN": "op://vault/item/field"},
+				Status: StringList{"true"},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	status := statusRuns(t, runner)
+	require.Len(t, status, 1)
+	assert.True(t, status[0].UseOpRun, "status probes must see resolved op:// secrets")
+}
+
+func TestStatusRunsDuringDryRun(t *testing.T) {
+	// Like preconditions, status probes are read-only checks: they still run
+	// under --dry so the printed plan reflects what a real run would skip.
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"create-bucket": {
+				Status: StringList{"true"},
+				Cmds:   []Cmd{{Cmd: "echo creating"}},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+	runner.DryRun = true
+	execs := captureExecs(runner)
+
+	err := runner.Run("create-bucket", "")
+	require.NoError(t, err)
+	assert.Len(t, statusRuns(t, runner), 1)
+	assert.Empty(t, *execs)
+}
+
+func TestStatusReceivesTaskEnv(t *testing.T) {
+	dir := t.TempDir()
+	tf := &Config{
+		Dir: dir,
+		Tasks: map[string]Task{
+			"deploy": {
+				Env:    map[string]string{"BUCKET": "artifacts"},
+				Status: StringList{"true"},
+			},
+		},
+		DotenvVars: make(map[string]string),
+	}
+
+	runner := newTestRunner(t, tf, dir)
+
+	err := runner.Run("deploy", "")
+	require.NoError(t, err)
+
+	status := statusRuns(t, runner)
+	require.Len(t, status, 1)
+	assert.Equal(t, "artifacts", envValue(status[0].Env, "BUCKET"))
+}

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -137,6 +137,14 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, paren
 		return nil
 	}
 
+	// Prompt before anything runs — deps included — so declining leaves the
+	// system untouched.
+	if task.Prompt != "" {
+		if err := r.confirmPrompt(resolved, task.Prompt); err != nil {
+			return err
+		}
+	}
+
 	if err := r.runDeps(task.Deps); err != nil {
 		return err
 	}

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -189,9 +190,21 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, paren
 
 // runCmds executes a list of commands in sequence. When silent is true, the
 // per-cmd "[task] cmd" log line is suppressed; the command itself still runs
-// and its own stdout/stderr are unaffected.
+// and its own stdout/stderr are unaffected. Deferred commands (`defer:`)
+// registered before a failure still run after the task's body, in reverse
+// registration order — they exist for cleanup, so a failed cmd must not skip
+// them.
 func (r *Runner) runCmds(taskName string, cmds []Cmd, vars map[string]string, cliArgs, dir string, env []string, useOpRun, silent bool) error {
+	var deferred []string
+	defer func() {
+		r.runDeferred(taskName, deferred, dir, env, useOpRun, silent)
+	}()
+
 	for _, cmd := range cmds {
+		if cmd.Defer != "" {
+			deferred = append(deferred, expandVars(cmd.Defer, vars, cliArgs, r.builtinLookup))
+			continue
+		}
 		if cmd.Task != "" {
 			// `task: X` sub-calls inherit the parent's resolved env so a
 			// task-level `env:` block flows down without the user having to
@@ -221,6 +234,24 @@ func (r *Runner) runCmds(taskName string, cmds []Cmd, vars map[string]string, cl
 		}
 	}
 	return nil
+}
+
+// runDeferred executes deferred commands in reverse registration order,
+// mirroring Go's defer semantics. A deferred command failure is logged as a
+// warning rather than returned: cleanup must not mask the task's own result,
+// and later defers must still run.
+func (r *Runner) runDeferred(taskName string, cmds []string, dir string, env []string, useOpRun, silent bool) {
+	for _, cmd := range slices.Backward(cmds) {
+		if !silent {
+			r.logTask(colorGreen, taskName, cmd)
+		}
+		if r.DryRun {
+			continue
+		}
+		if err := r.runShellTaskCommand(taskName, cmd, dir, env, useOpRun); err != nil {
+			r.logTask(colorYellow, taskName, fmt.Sprintf("warning: deferred command failed: %v", err))
+		}
+	}
 }
 
 // runDeps executes task dependencies concurrently.

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -176,6 +176,13 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, paren
 	if err != nil {
 		return err
 	}
+	// `status:` probes the desired end state. With no sources it decides
+	// alone; with sources both must agree, so either signal forces a run.
+	// It's only consulted when it can still flip the answer — changed
+	// sources already force a run, no point shelling out on top.
+	if !r.Force && len(task.Status) > 0 && (len(task.Sources) == 0 || upToDate) {
+		upToDate = r.statusUpToDate(resolved, &task, dir, env)
+	}
 	if upToDate {
 		r.logTask(colorYellow, resolved, "up to date")
 		return nil

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -230,6 +230,10 @@ func (r *Runner) runCmds(taskName string, cmds []Cmd, vars map[string]string, cl
 			r.logTask(colorGreen, taskName, expanded)
 		}
 		if err := r.runShellTaskCommand(taskName, expanded, dir, env, useOpRun); err != nil {
+			if cmd.IgnoreError {
+				r.logTask(colorYellow, taskName, fmt.Sprintf("warning: command failed (ignored): %v", err))
+				continue
+			}
 			return err
 		}
 	}

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -100,10 +100,11 @@ func (sl *StringList) UnmarshalYAML(unmarshal func(any) error) error {
 // Cmd represents a command in a task. It can be a simple string, a task
 // reference, or a deferred cleanup command.
 type Cmd struct {
-	Cmd   string         `yaml:"cmd"`
-	Task  string         `yaml:"task"`
-	Defer string         `yaml:"defer"` // shell command run after the task's cmds, even on failure
-	Vars  map[string]Var `yaml:"vars"`
+	Cmd         string         `yaml:"cmd"`
+	Task        string         `yaml:"task"`
+	Defer       string         `yaml:"defer"`        // shell command run after the task's cmds, even on failure
+	IgnoreError bool           `yaml:"ignore_error"` // when true, a failure of this cmd doesn't stop the task (shell cmds only; not honored on task: or defer: entries)
+	Vars        map[string]Var `yaml:"vars"`
 }
 
 // isSet returns true if the Cmd has a command, task reference, or deferred command.

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -34,6 +34,7 @@ type Task struct {
 	Platforms     StringList        `yaml:"platforms"`
 	Requires      Requires          `yaml:"requires"`
 	Preconditions []Precondition    `yaml:"preconditions"`
+	Prompt        string            `yaml:"prompt"` // confirmation message shown before the task runs
 	Silent        bool              `yaml:"silent"` // when true, suppress the per-cmd "[task] cmd" log line
 	Desc          string            `yaml:"-"`      // set from YAML comments, not from a field
 }

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -97,16 +97,18 @@ func (sl *StringList) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
-// Cmd represents a command in a task. It can be a simple string or a task reference.
+// Cmd represents a command in a task. It can be a simple string, a task
+// reference, or a deferred cleanup command.
 type Cmd struct {
-	Cmd  string         `yaml:"cmd"`
-	Task string         `yaml:"task"`
-	Vars map[string]Var `yaml:"vars"`
+	Cmd   string         `yaml:"cmd"`
+	Task  string         `yaml:"task"`
+	Defer string         `yaml:"defer"` // shell command run after the task's cmds, even on failure
+	Vars  map[string]Var `yaml:"vars"`
 }
 
-// isSet returns true if the Cmd has a command or task reference.
+// isSet returns true if the Cmd has a command, task reference, or deferred command.
 func (c *Cmd) isSet() bool {
-	return c.Cmd != "" || c.Task != ""
+	return c.Cmd != "" || c.Task != "" || c.Defer != ""
 }
 
 // UnmarshalYAML allows Cmd to be either a string or a map.

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -30,6 +30,7 @@ type Task struct {
 	Secrets       StringList        `yaml:"secrets"` // names referencing entries in Config.Secrets
 	Sources       StringList        `yaml:"sources"`
 	Generates     StringList        `yaml:"generates"`
+	Status        StringList        `yaml:"status"` // shell commands; when all exit 0 the task is up to date
 	Aliases       StringList        `yaml:"aliases"`
 	Platforms     StringList        `yaml:"platforms"`
 	Requires      Requires          `yaml:"requires"`

--- a/taskfile/uptodate.go
+++ b/taskfile/uptodate.go
@@ -34,3 +34,26 @@ func (r *Runner) isUpToDate(task *Task, dir, taskName string, force bool) (bool,
 
 	return checksum == readStoredChecksum(r.tf.Dir, taskName), checksum, nil
 }
+
+// statusUpToDate reports whether every `status:` command exits 0, meaning
+// the task's desired end state already exists and it can be skipped. The
+// first failing command short-circuits: one "not done" answer is enough.
+// Status commands see the task's full env — including op:// secret
+// resolution — exactly like preconditions, so probes can read the same
+// credentials the task itself would use.
+func (r *Runner) statusUpToDate(taskName string, task *Task, dir string, env []string) bool {
+	useOpRun := hasOpSecrets(env)
+	for _, sh := range task.Status {
+		if err := r.ShellRunner.Run(ShellCommand{
+			Kind:     ShellCommandStatus,
+			TaskName: taskName,
+			Command:  sh,
+			Dir:      dir,
+			Env:      env,
+			UseOpRun: useOpRun,
+		}); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -58,6 +58,7 @@ func expandTaskTemplates(t *Task) {
 	t.Dir = expandEnvTemplates(t.Dir)
 	expandStringSlice(t.Sources)
 	expandStringSlice(t.Generates)
+	expandStringSlice(t.Status)
 	expandStringSlice(t.Aliases)
 	expandStringSlice(t.Platforms)
 	expandStringSlice(t.Dotenv)

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -230,6 +230,9 @@ func referencedVars(task *Task) []string {
 		for _, name := range templateNames(cmd.Cmd) {
 			refs[name] = struct{}{}
 		}
+		for _, name := range templateNames(cmd.Defer) {
+			refs[name] = struct{}{}
+		}
 		for _, v := range cmd.Vars {
 			for _, name := range templateNames(v.Value) {
 				refs[name] = struct{}{}


### PR DESCRIPTION
This PR adds four new task-runner features inspired by go-task, each with comprehensive tests and documentation.

**`defer:` cleanup commands** register teardown steps that run after a task's body finishes — even when a command fails. They execute in reverse registration order (LIFO), letting you guarantee cleanup: start a service, defer its stop, then run tests knowing the service will shut down regardless of test outcome. Deferred failures log warnings but don't fail the task itself, preserving the original error.

**Per-cmd `ignore_error: true`** lets individual commands fail without aborting the task. A failing command logs a warning and execution continues to the next step, useful for cleanup steps that may not exist or minor health checks. Scoped narrowly to shell commands, so child-task failures still propagate normally.

**`prompt:` confirmation** asks for `[y/N]` on stderr before a task and its dependencies run, perfect for guarding destructive operations. Only `y` or `yes` (case-insensitive) proceed; anything else — including EOF or Enter — declines and aborts. Two shortcuts skip the question: `--yes` / `-y` auto-confirms all prompts (great for CI), and `--dry` skips it since nothing executes. The prompt reads stdin byte-wise so piped input after the answer still reaches the task.

**`status:` end-state probes** replace the up-to-date check with custom shell commands. All probes must exit 0 for the task to be skipped; any failure means the work needs doing. When a task has both `sources` and `status`, both must agree (status is only checked when sources are up to date). Status commands see the full task environment including op:// secret resolution, so you can probe remote systems authenticated with secrets.

All four features are individually green across build, tests, and linters, and each is documented in `docs/features/` and the README.