### PR TITLE
Fix included project root discovery with sibling namespace access

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -516,6 +516,52 @@ tasks:
 	assert.NotContains(t, stderr.String(), "echo root-build")
 }
 
+func TestAppCanRunRootTaskWithSelfPrefixFromIncludedSubProject(t *testing.T) {
+	dir := t.TempDir()
+	rootName := filepath.Base(dir)
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+tasks:
+  build:
+    cmd: echo root-build
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry", rootName+":build")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[build]")
+	assert.Contains(t, stderr.String(), "echo root-build")
+	assert.NotContains(t, stderr.String(), "echo p2-build")
+}
+
+func TestAppPrefersIncludedProjectAliasFromIncludedSubProject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+tasks:
+  b:
+    cmd: echo root-b
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    aliases: [b]
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry", "b")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[p2:build]")
+	assert.Contains(t, stderr.String(), "echo p2-build")
+	assert.NotContains(t, stderr.String(), "echo root-b")
+}
+
 func TestAppUsesIncludedProjectDefaultFromIncludedSubProject(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
@@ -533,6 +579,26 @@ tasks:
 	require.NoError(t, app.Run(t.Context()))
 	assert.Contains(t, stderr.String(), "[p2:build]")
 	assert.Contains(t, stderr.String(), "echo p2-build")
+}
+
+func TestAppRejectsMissingIncludedProjectDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+default: missing
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, _ := newTestApp(t, dir, "--list")
+
+	err := app.Run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `include "p2" default:`)
+	assert.Contains(t, err.Error(), `p2:missing`)
 }
 
 func TestAppReportsInvalidIncludingAncestor(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -494,6 +494,27 @@ tasks:
 	assert.Contains(t, stderr.String(), "echo workspace-p1-build")
 }
 
+func TestAppReportsInvalidIncludingAncestor(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+tasks:
+  bad/name:
+    cmd: echo invalid
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, _ := newTestApp(t, filepath.Join(dir, "p2"), "--dry", "build")
+
+	err := app.Run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `bad/name`)
+}
+
 func TestAppDoesNotUseAncestorThatDoesNotIncludeCurrentProject(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"

--- a/app_test.go
+++ b/app_test.go
@@ -255,19 +255,19 @@ func TestAppPropagatesGetwdError(t *testing.T) {
 
 func TestDefaultTaskNamesUsesTopLevelDefault(t *testing.T) {
 	tf := &taskfile.Config{Default: "build"}
-	assert.Equal(t, []string{"build"}, defaultTaskNames(nil, tf))
+	assert.Equal(t, []string{"build"}, defaultTaskNames(nil, tf, ""))
 
 	// Explicit positional args always win over the top-level field, so
 	// `gogo test` still runs `test` even when default: build is declared.
-	assert.Equal(t, []string{"test"}, defaultTaskNames([]string{"test"}, tf))
-	assert.Equal(t, []string{"clean", "install"}, defaultTaskNames([]string{"clean", "install"}, tf))
+	assert.Equal(t, []string{"test"}, defaultTaskNames([]string{"test"}, tf, ""))
+	assert.Equal(t, []string{"clean", "install"}, defaultTaskNames([]string{"clean", "install"}, tf, ""))
 }
 
 func TestDefaultTaskNamesFallbackWhenUnset(t *testing.T) {
 	// Backward compatibility: with no top-level default the implicit
 	// "task literally named default" convention still works.
 	tf := &taskfile.Config{}
-	assert.Equal(t, []string{"default"}, defaultTaskNames(nil, tf))
+	assert.Equal(t, []string{"default"}, defaultTaskNames(nil, tf, ""))
 }
 
 func TestAppHelpDoesNotExposeCLIArgsFlag(t *testing.T) {
@@ -492,6 +492,47 @@ tasks:
 	require.NoError(t, app.Run(t.Context()))
 	assert.Contains(t, stderr.String(), "[p1:build]")
 	assert.Contains(t, stderr.String(), "echo workspace-p1-build")
+}
+
+func TestAppPrefersIncludedProjectTaskFromIncludedSubProject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+tasks:
+  build:
+    cmd: echo root-build
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry", "build")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[p2:build]")
+	assert.Contains(t, stderr.String(), "echo p2-build")
+	assert.NotContains(t, stderr.String(), "echo root-build")
+}
+
+func TestAppUsesIncludedProjectDefaultFromIncludedSubProject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p2]
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+default: build
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[p2:build]")
+	assert.Contains(t, stderr.String(), "echo p2-build")
 }
 
 func TestAppReportsInvalidIncludingAncestor(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -443,3 +443,76 @@ tasks:
 	assert.Contains(t, out, `task: task "xyzzy" not found`)
 	assert.NotContains(t, out, "did you mean")
 }
+
+func TestAppRunsSiblingIncludedTaskFromIncludedSubProject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p1, p2]
+`)
+	writeFile(t, filepath.Join(dir, "p1", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p1-build
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry", "p1:build")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[p1:build]")
+	assert.Contains(t, stderr.String(), "echo p1-build")
+}
+
+func TestAppDoesNotClimbPastNearestIncludingAncestor(t *testing.T) {
+	dir := t.TempDir()
+	workspace := filepath.Join(dir, "workspace")
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [workspace]
+`)
+	writeFile(t, filepath.Join(workspace, "gogo.yaml"), `version: "1"
+includes: [p1, p2]
+`)
+	writeFile(t, filepath.Join(workspace, "p1", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo workspace-p1-build
+`)
+	writeFile(t, filepath.Join(workspace, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo workspace-p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(workspace, "p2"), "--dry", "p1:build")
+
+	require.NoError(t, app.Run(t.Context()))
+	assert.Contains(t, stderr.String(), "[p1:build]")
+	assert.Contains(t, stderr.String(), "echo workspace-p1-build")
+}
+
+func TestAppDoesNotUseAncestorThatDoesNotIncludeCurrentProject(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gogo.yaml"), `version: "1"
+includes: [p1]
+`)
+	writeFile(t, filepath.Join(dir, "p1", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p1-build
+`)
+	writeFile(t, filepath.Join(dir, "p2", "gogo.yaml"), `version: "1"
+tasks:
+  build:
+    cmd: echo p2-build
+`)
+
+	app, _, stderr := newTestApp(t, filepath.Join(dir, "p2"), "--dry", "p1:build")
+
+	err := app.Run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), `task "p1:build" not found`)
+}

--- a/docs/features/includes/index.md
+++ b/docs/features/includes/index.md
@@ -52,6 +52,15 @@ cd backend
 gogo build      # resolves to backend:build
 ```
 
+If `backend/` and `frontend/` each have their own `gogo.yaml` and the parent task file includes both, gogo still uses the parent include root when run from either sub-project. That makes sibling namespaces available from every included project:
+
+```sh
+cd backend
+gogo frontend:test
+```
+
+This promotion only happens for the nearest ancestor task file that directly includes the current project, so unrelated higher-level `gogo.yaml` files are ignored.
+
 ## Dotenv Deduplication
 
 Each included task file can define its own `dotenv` files. If multiple includes reference the same `.env` file (by absolute path), it's loaded only once.

--- a/main.go
+++ b/main.go
@@ -111,7 +111,10 @@ func (a *App) Run(ctx context.Context) error {
 	runner.Force = parsed.Force
 	runner.AssumeYes = parsed.Yes
 
-	taskNames := defaultTaskNames(parsed.Tasks, tf)
+	cwdNamespace, hasCwdNamespace := taskfile.NamespaceForDir(tf, dir)
+	runner.PreferCwdNamespace = hasCwdNamespace
+
+	taskNames := defaultTaskNames(parsed.Tasks, tf, cwdNamespace)
 
 	if parsed.Watch {
 		if len(taskNames) != 1 {
@@ -169,9 +172,14 @@ var errSilent = errors.New("")
 // given. A top-level `default:` field in the task file wins over the
 // implicit "task literally named default" convention, which lets users
 // skip the `default:` trampoline entirely.
-func defaultTaskNames(parsed []string, tf *taskfile.Config) []string {
+func defaultTaskNames(parsed []string, tf *taskfile.Config, cwdNamespace string) []string {
 	if len(parsed) > 0 {
 		return parsed
+	}
+	if cwdNamespace != "" {
+		if name := tf.NamespaceDefaults[cwdNamespace]; name != "" {
+			return []string{name}
+		}
 	}
 	if tf.Default != "" {
 		return []string{tf.Default}

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -73,6 +73,7 @@ func (l *includeLoader) load() (*Config, error) {
 	l.root.Namespaces = make(map[string]string)
 	l.root.NamespaceDirs = make(map[string]string)
 	l.root.NamespaceVars = make(map[string]map[string]Var)
+	l.root.NamespaceDefaults = make(map[string]string)
 
 	// Process flatten files first (their tasks merge into the root namespace).
 	// Order vs. includes doesn't matter for correctness because both honor
@@ -170,6 +171,7 @@ func (l *includeLoader) loadInclude(req includeRequest) error {
 	}
 
 	l.mergeVars(included.Namespace, included.Dir, included.Vars)
+	l.mergeDefault(included.Namespace, included.Default)
 	l.mergeSourcePresets(included.Sources)
 	l.mergeSecrets(included.Secrets)
 	return l.mergeTasks(included)
@@ -353,6 +355,18 @@ func (l *includeLoader) mergeVars(namespace, dir string, vars map[string]Var) {
 		if _, exists := scoped[k]; !exists {
 			scoped[k] = v
 		}
+	}
+}
+
+func (l *includeLoader) mergeDefault(namespace, defaultTask string) {
+	if namespace == "" || defaultTask == "" {
+		return
+	}
+	if l.root.NamespaceDefaults == nil {
+		l.root.NamespaceDefaults = make(map[string]string)
+	}
+	if _, exists := l.root.NamespaceDefaults[namespace]; !exists {
+		l.root.NamespaceDefaults[namespace] = namespaceJoin(namespace, defaultTask)
 	}
 }
 

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -104,6 +104,9 @@ func (l *includeLoader) load() (*Config, error) {
 	if err := validateDefaultTask(l.root); err != nil {
 		return nil, err
 	}
+	if err := validateNamespaceDefaults(l.root); err != nil {
+		return nil, err
+	}
 	if err := validateSecrets(l.root); err != nil {
 		return nil, err
 	}
@@ -121,6 +124,16 @@ func validateDefaultTask(c *Config) error {
 		return nil
 	}
 	return fmt.Errorf("top-level default: %q does not reference any defined task", c.Default)
+}
+
+func validateNamespaceDefaults(c *Config) error {
+	for namespace, defaultTask := range c.NamespaceDefaults {
+		if _, ok := c.Tasks[defaultTask]; ok {
+			continue
+		}
+		return fmt.Errorf("include %q default: %q does not reference any defined task", namespace, defaultTask)
+	}
+	return nil
 }
 
 type includeRequest struct {

--- a/taskfile/parse.go
+++ b/taskfile/parse.go
@@ -92,23 +92,66 @@ func findFile(dir string) string {
 	return ""
 }
 
-// FindRootDir walks up from dir to find the nearest directory containing a gogo.yaml.
+// FindRootDir walks up from dir to find the task-file root to use.
+//
+// A standalone nested gogo.yaml remains the root for commands run below it.
+// However, when its nearest task-file ancestor directly includes that nested
+// project, the ancestor is the project root: loading it makes sibling include
+// namespaces available from any included sub-project without climbing into
+// unrelated higher-level task files.
 func FindRootDir(dir string) (string, error) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", err
 	}
 
+	candidates := taskFileDirs(dir)
+	if len(candidates) == 0 {
+		return "", errors.New("no gogo.yaml found")
+	}
+
+	nearest := candidates[0]
+	for i := 1; i < len(candidates); i++ {
+		candidate := candidates[i]
+		if configDirectlyIncludesDir(candidate, nearest) {
+			return candidate, nil
+		}
+	}
+
+	return nearest, nil
+}
+
+func taskFileDirs(dir string) []string {
+	var dirs []string
 	for {
 		if findFile(dir) != "" {
-			return dir, nil
+			dirs = append(dirs, dir)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			break
+			return dirs
 		}
 		dir = parent
 	}
+}
 
-	return "", errors.New("no gogo.yaml found")
+func configDirectlyIncludesDir(configDir, dir string) bool {
+	tf, err := Parse(configDir)
+	if err != nil {
+		return false
+	}
+	dir = filepath.Clean(dir)
+	for _, includeName := range tf.Includes {
+		if validateIncludeName(includeName) != nil {
+			continue
+		}
+		includeDir, err := filepath.Abs(filepath.Join(configDir, includeName))
+		if err != nil {
+			continue
+		}
+		if filepath.Clean(includeDir) == dir {
+			return true
+		}
+	}
+	return false
 }

--- a/taskfile/parse.go
+++ b/taskfile/parse.go
@@ -136,12 +136,12 @@ func taskFileDirs(dir string) []string {
 }
 
 func configDirectlyIncludesDir(configDir, dir string) bool {
-	tf, err := Parse(configDir)
+	includes, err := parseIncludesOnly(configDir)
 	if err != nil {
 		return false
 	}
 	dir = filepath.Clean(dir)
-	for _, includeName := range tf.Includes {
+	for _, includeName := range includes {
 		if validateIncludeName(includeName) != nil {
 			continue
 		}
@@ -154,4 +154,23 @@ func configDirectlyIncludesDir(configDir, dir string) bool {
 		}
 	}
 	return false
+}
+
+func parseIncludesOnly(dir string) ([]string, error) {
+	path := findFile(dir)
+	if path == "" {
+		return nil, fmt.Errorf("no gogo.yaml found in %s", dir)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var tf struct {
+		Includes []string `yaml:"includes"`
+	}
+	if err := yaml.Unmarshal(data, &tf); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	expandStringSlice(tf.Includes)
+	return tf.Includes, nil
 }

--- a/taskfile/runner.go
+++ b/taskfile/runner.go
@@ -35,18 +35,19 @@ func defaultRunnerIO() RunnerIO {
 
 // Runner executes tasks from a loaded task file.
 type Runner struct {
-	tf          *Config
-	cwd         string
-	BaseEnv     []string          // base process environment (defaults to os.Environ() + dotenv)
-	aliases     map[string]string // alias -> task name
-	DryRun      bool              // if true, print commands without executing them
-	Force       bool              // if true, ignore sources and generates (always run)
-	AssumeYes   bool              // if true, task prompts are auto-confirmed (--yes)
-	ShellRunner ShellRunner       // replaceable shell executor (defaults to real exec)
-	IO          RunnerIO          // process streams used for logs and command stdio
-	runs        sync.Map          // resolved task name -> *taskRun
-	gitVars     *gitVars          // lazy {{.GIT_*}} resolver, built on first reference
-	gitOnce     sync.Once         // guards gitVars construction
+	tf                 *Config
+	cwd                string
+	BaseEnv            []string          // base process environment (defaults to os.Environ() + dotenv)
+	aliases            map[string]string // alias -> task name
+	DryRun             bool              // if true, print commands without executing them
+	Force              bool              // if true, ignore sources and generates (always run)
+	AssumeYes          bool              // if true, task prompts are auto-confirmed (--yes)
+	PreferCwdNamespace bool              // if true, bare task names resolve in the cwd namespace before root tasks
+	ShellRunner        ShellRunner       // replaceable shell executor (defaults to real exec)
+	IO                 RunnerIO          // process streams used for logs and command stdio
+	runs               sync.Map          // resolved task name -> *taskRun
+	gitVars            *gitVars          // lazy {{.GIT_*}} resolver, built on first reference
+	gitOnce            sync.Once         // guards gitVars construction
 }
 
 // taskRun memoizes a single task execution. The first caller runs the body;

--- a/taskfile/runner.go
+++ b/taskfile/runner.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 )
 
@@ -69,10 +70,14 @@ func NewRunner(tf *Config, cwd string) (*Runner, error) {
 	aliases := make(map[string]string)
 	for _, name := range slices.Sorted(maps.Keys(tf.Tasks)) {
 		for _, alias := range tf.Tasks[name].Aliases {
-			if existing, ok := aliases[alias]; ok {
-				return nil, fmt.Errorf("alias %q is defined by both %q and %q", alias, existing, name)
+			if err := addAlias(aliases, alias, name); err != nil {
+				return nil, err
 			}
-			aliases[alias] = name
+			if ns := taskNamespace(name); ns != "" && !strings.Contains(alias, ":") {
+				if err := addAlias(aliases, ns+":"+alias, name); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
 
@@ -85,6 +90,14 @@ func NewRunner(tf *Config, cwd string) (*Runner, error) {
 		IO:          defaultRunnerIO(),
 	}
 	return r, nil
+}
+
+func addAlias(aliases map[string]string, alias, taskName string) error {
+	if existing, ok := aliases[alias]; ok {
+		return fmt.Errorf("alias %q is defined by both %q and %q", alias, existing, taskName)
+	}
+	aliases[alias] = taskName
+	return nil
 }
 
 // builtinLookup returns the value of a gogo-provided variable (currently

--- a/taskfile/task_resolution.go
+++ b/taskfile/task_resolution.go
@@ -143,8 +143,9 @@ func (r *Runner) nameCandidates(name string) []string {
 	base := filepath.Base(r.tf.Dir)
 	ns, hasNS := r.cwdNamespace()
 	var out []string
+	strippedSelfPrefix := false
 	for cur := name; ; {
-		if hasNS && r.PreferCwdNamespace && !strings.Contains(cur, ":") {
+		if hasNS && r.PreferCwdNamespace && !strippedSelfPrefix && !strings.Contains(cur, ":") {
 			out = append(out, ns+":"+cur, cur)
 		} else {
 			out = append(out, cur)
@@ -156,6 +157,7 @@ func (r *Runner) nameCandidates(name string) []string {
 		if !hasColon || prefix != base {
 			return out
 		}
+		strippedSelfPrefix = true
 		cur = suffix
 	}
 }

--- a/taskfile/task_resolution.go
+++ b/taskfile/task_resolution.go
@@ -135,18 +135,22 @@ func segmentPrefixMatch(taskName string, candSegs []string) bool {
 }
 
 // nameCandidates lists the interpretations of name, in priority order, that
-// resolution should try. The literal name comes first; then — when cwd sits
-// inside an included namespace — the cwd-namespaced form; then, recursively,
-// the name with a self-prefix stripped (matching the task file root's
-// basename). Both exact and prefix matching walk this same list.
+// resolution should try. The root/literal name normally comes first. When the
+// CLI promoted an included project to its parent include root, bare names from
+// inside that project prefer the cwd namespace so `gogo build` still behaves
+// like it did when the sub-project ran standalone.
 func (r *Runner) nameCandidates(name string) []string {
 	base := filepath.Base(r.tf.Dir)
 	ns, hasNS := r.cwdNamespace()
 	var out []string
 	for cur := name; ; {
-		out = append(out, cur)
-		if hasNS {
-			out = append(out, ns+":"+cur)
+		if hasNS && r.PreferCwdNamespace && !strings.Contains(cur, ":") {
+			out = append(out, ns+":"+cur, cur)
+		} else {
+			out = append(out, cur)
+			if hasNS {
+				out = append(out, ns+":"+cur)
+			}
 		}
 		prefix, suffix, hasColon := strings.Cut(cur, ":")
 		if !hasColon || prefix != base {
@@ -156,21 +160,25 @@ func (r *Runner) nameCandidates(name string) []string {
 	}
 }
 
-// cwdNamespace returns the most specific namespace whose directory contains
-// the runner's current working directory. Used to let users invoke tasks by
-// their short name when cwd sits under an included task file.
-func (r *Runner) cwdNamespace() (string, bool) {
+// NamespaceForDir returns the most specific namespace whose directory contains
+// dir. Used to let users invoke tasks by their short name when cwd sits under
+// an included task file.
+func NamespaceForDir(tf *Config, dir string) (string, bool) {
 	var bestDir, bestNS string
-	for dir, ns := range r.tf.Namespaces {
-		if !strings.HasPrefix(r.cwd+string(filepath.Separator), dir+string(filepath.Separator)) {
+	for namespaceDir, ns := range tf.Namespaces {
+		if !strings.HasPrefix(dir+string(filepath.Separator), namespaceDir+string(filepath.Separator)) {
 			continue
 		}
-		if len(dir) > len(bestDir) {
-			bestDir = dir
+		if len(namespaceDir) > len(bestDir) {
+			bestDir = namespaceDir
 			bestNS = ns
 		}
 	}
 	return bestNS, bestNS != ""
+}
+
+func (r *Runner) cwdNamespace() (string, bool) {
+	return NamespaceForDir(r.tf, r.cwd)
 }
 
 // IsInternalTask reports whether a task name is internal (its local segment

--- a/taskfile/types.go
+++ b/taskfile/types.go
@@ -2,21 +2,22 @@ package taskfile
 
 // Config represents a parsed gogo.yaml.
 type Config struct {
-	Version       string                    `yaml:"version"`
-	Includes      []string                  `yaml:"includes"`
-	Flatten       []string                  `yaml:"flatten"` // YAML files whose tasks merge into this config without a namespace
-	Dotenv        []string                  `yaml:"dotenv"`
-	Default       string                    `yaml:"default"` // task to run when none is given on the CLI; replaces the convention of declaring a `default` task
-	Vars          map[string]Var            `yaml:"vars"`    // vars declared at the root (namespace "")
-	Sources       map[string]StringList     `yaml:"sources"` // named source presets, referenced from task.Sources by name
-	Secrets       map[string]string         `yaml:"secrets"` // named secret URIs (op://, aws-creds://, ...), referenced from task.Secrets
-	Tasks         map[string]Task           `yaml:"tasks"`
-	Dir           string                    `yaml:"-"`
-	Interval      string                    `yaml:"interval"`
-	Namespaces    map[string]string         `yaml:"-"` // dir -> namespace
-	NamespaceDirs map[string]string         `yaml:"-"` // namespace -> dir (where each include's gogo.yaml lives, used to resolve `sh:` vars in their own working dir)
-	NamespaceVars map[string]map[string]Var `yaml:"-"` // namespace -> vars declared at that namespace; not visible to sibling namespaces
-	DotenvVars    map[string]string         `yaml:"-"` // resolved dotenv variables
+	Version           string                    `yaml:"version"`
+	Includes          []string                  `yaml:"includes"`
+	Flatten           []string                  `yaml:"flatten"` // YAML files whose tasks merge into this config without a namespace
+	Dotenv            []string                  `yaml:"dotenv"`
+	Default           string                    `yaml:"default"` // task to run when none is given on the CLI; replaces the convention of declaring a `default` task
+	Vars              map[string]Var            `yaml:"vars"`    // vars declared at the root (namespace "")
+	Sources           map[string]StringList     `yaml:"sources"` // named source presets, referenced from task.Sources by name
+	Secrets           map[string]string         `yaml:"secrets"` // named secret URIs (op://, aws-creds://, ...), referenced from task.Secrets
+	Tasks             map[string]Task           `yaml:"tasks"`
+	Dir               string                    `yaml:"-"`
+	Interval          string                    `yaml:"interval"`
+	Namespaces        map[string]string         `yaml:"-"` // dir -> namespace
+	NamespaceDirs     map[string]string         `yaml:"-"` // namespace -> dir (where each include's gogo.yaml lives, used to resolve `sh:` vars in their own working dir)
+	NamespaceVars     map[string]map[string]Var `yaml:"-"` // namespace -> vars declared at that namespace; not visible to sibling namespaces
+	NamespaceDefaults map[string]string         `yaml:"-"` // namespace -> resolved default task for that include
+	DotenvVars        map[string]string         `yaml:"-"` // resolved dotenv variables
 }
 
 // Task represents a single task definition.


### PR DESCRIPTION
When a nested `gogo.yaml` is directly included by an ancestor, that ancestor becomes the project root instead of stopping at the nearest standalone task file. This ensures commands run from any included sub-project can access sibling namespaces without climbing into unrelated higher-level task files — a critical behavior for multi-project monorepos where each component has its own `gogo.yaml`.

The fix refines `FindRootDir` to detect when a candidate ancestor directly includes the current directory via its `includes:` list. If found, that ancestor is promoted to root, preventing unrelated task files further up the tree from interfering. Standalone task files not directly including their descendants remain the root as before, so local-only projects continue to work unchanged.

Preserves local project behavior, validates include-root discovery strictly, updates documentation, and includes comprehensive tests covering edge cases like sibling access and unrelated ancestor rejection.