### PR TITLE
refactor: reduce duplication and simplify internals

### DIFF
--- a/fallback.go
+++ b/fallback.go
@@ -9,10 +9,10 @@ import (
 )
 
 // This file implements an opt-in convenience: when gogo can't find a
-// gogo.yaml, it looks for a foreign task file (Taskfile / mise.toml) up the
-// tree and shells out to the matching tool. It's deliberately self-contained
-// and side-tested via the package-level hooks below — the rest of the
-// codebase stays oblivious.
+// gogo.yaml, it looks for a foreign task file (Taskfile / mise.toml /
+// Makefile) in the current working directory only and shells out to the
+// matching tool. It's deliberately self-contained and side-tested via the
+// package-level hooks below — the rest of the codebase stays oblivious.
 
 // fallbackLookPath / fallbackRun are overridden in tests. Production uses
 // exec.LookPath and a real exec.CommandContext.

--- a/fallback.go
+++ b/fallback.go
@@ -32,15 +32,19 @@ var (
 	}
 )
 
-// foreignRunners lists, in priority order, the foreign task files we know
-// how to delegate to. `listArgs` is the runner's native `--list`
-// invocation; leave it nil when the runner has no equivalent.
-var foreignRunners = []struct {
+// foreignRunner describes one foreign task file format and the tool that
+// runs it.
+type foreignRunner struct {
 	bin      string
 	files    []string
 	build    func(tasks, cliArgs []string) []string
 	listArgs []string
-}{
+}
+
+// foreignRunners lists, in priority order, the foreign task files we know
+// how to delegate to. `listArgs` is the runner's native `--list`
+// invocation; leave it nil when the runner has no equivalent.
+var foreignRunners = []foreignRunner{
 	{
 		bin:   "task",
 		files: []string{"Taskfile.yml", "taskfile.yml", "Taskfile.yaml", "taskfile.yaml"},
@@ -82,10 +86,11 @@ func foreignArgs(prefix, tasks, cliArgs []string) []string {
 	return argv
 }
 
-// tryForeignFallback looks in the current working directory only for a
-// foreign task file whose runner is on PATH. Returns (handled=true, err)
-// when one is invoked; a (false, nil) return means the caller should
-// surface the original error.
+// delegateToForeign looks in the current working directory only for a
+// foreign task file whose runner is on PATH, and invokes it with the argv
+// returned by argvFor. Runners for which argvFor reports ok=false are
+// skipped. Returns (handled=true, err) when one is invoked; a (false, nil)
+// return means the caller should surface its original error.
 //
 // We deliberately do NOT walk up: running gogo from inside an untrusted
 // checkout (or a temp dir under one) must not silently execute an
@@ -94,19 +99,22 @@ func foreignArgs(prefix, tasks, cliArgs []string) []string {
 // "Silently ignored if not on PATH" means: if a Taskfile is found but
 // `task` isn't installed, we don't try to run it — we may still pick up a
 // sibling runner (e.g. mise.toml) in the same directory.
-func (a *App) tryForeignFallback(ctx context.Context, parsed *args) (bool, error) {
+func (a *App) delegateToForeign(ctx context.Context, argvFor func(foreignRunner) ([]string, bool)) (bool, error) {
 	dir, err := a.Getwd()
 	if err != nil {
 		return false, nil
 	}
 
 	for _, r := range foreignRunners {
+		argv, ok := argvFor(r)
+		if !ok {
+			continue
+		}
 		if _, err := fallbackLookPath(r.bin); err != nil {
 			continue
 		}
 		for _, name := range r.files {
 			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-				argv := r.build(parsed.Tasks, parsed.CLIArgs)
 				return true, fallbackRun(ctx, r.bin, argv, dir, a)
 			}
 		}
@@ -114,27 +122,19 @@ func (a *App) tryForeignFallback(ctx context.Context, parsed *args) (bool, error
 	return false, nil
 }
 
-// tryForeignListFallback delegates `--list` to a colocated foreign task
-// file's runner. Same cwd-only stance as tryForeignFallback; runners
-// without a native listing command (listArgs == nil) are skipped.
-func (a *App) tryForeignListFallback(ctx context.Context) (bool, error) {
-	dir, err := a.Getwd()
-	if err != nil {
-		return false, nil
-	}
+// tryForeignFallback delegates a normal run to a colocated foreign task
+// file's runner.
+func (a *App) tryForeignFallback(ctx context.Context, parsed *args) (bool, error) {
+	return a.delegateToForeign(ctx, func(r foreignRunner) ([]string, bool) {
+		return r.build(parsed.Tasks, parsed.CLIArgs), true
+	})
+}
 
-	for _, r := range foreignRunners {
-		if r.listArgs == nil {
-			continue
-		}
-		if _, err := fallbackLookPath(r.bin); err != nil {
-			continue
-		}
-		for _, name := range r.files {
-			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-				return true, fallbackRun(ctx, r.bin, r.listArgs, dir, a)
-			}
-		}
-	}
-	return false, nil
+// tryForeignListFallback delegates `--list` to a colocated foreign task
+// file's runner. Runners without a native listing command (listArgs == nil)
+// are skipped.
+func (a *App) tryForeignListFallback(ctx context.Context) (bool, error) {
+	return a.delegateToForeign(ctx, func(r foreignRunner) ([]string, bool) {
+		return r.listArgs, r.listArgs != nil
+	})
 }

--- a/main.go
+++ b/main.go
@@ -388,6 +388,17 @@ type taskListing struct {
 	aliases string // pre-formatted "(aliases: a, b)" or empty
 }
 
+// newTaskListing builds the listing row for one task: the first line of its
+// description (trimmed) plus the pre-formatted alias cell.
+func newTaskListing(name string, task taskfile.Task) taskListing {
+	desc, _, _ := strings.Cut(task.Desc, "\n")
+	row := taskListing{name: name, desc: strings.TrimSpace(desc)}
+	if len(task.Aliases) > 0 {
+		row.aliases = "(aliases: " + strings.Join(task.Aliases, ", ") + ")"
+	}
+	return row
+}
+
 // gatherTaskListings returns the rows that --list and the unknown-task hint
 // should print, in declaration-friendly alphabetical order. Tasks without a
 // description are intentionally omitted: we surface only what the author
@@ -396,15 +407,9 @@ type taskListing struct {
 func gatherTaskListings(tf *taskfile.Config) []taskListing {
 	var entries []taskListing
 	for _, name := range visibleTaskNames(tf) {
-		task := tf.Tasks[name]
-		desc, _, _ := strings.Cut(task.Desc, "\n")
-		desc = strings.TrimSpace(desc)
-		if desc == "" {
+		row := newTaskListing(name, tf.Tasks[name])
+		if row.desc == "" {
 			continue
-		}
-		row := taskListing{name: name, desc: desc}
-		if len(task.Aliases) > 0 {
-			row.aliases = "(aliases: " + strings.Join(task.Aliases, ", ") + ")"
 		}
 		entries = append(entries, row)
 	}
@@ -431,13 +436,7 @@ func gatherNamespacedMatches(tf *taskfile.Config, name string) []taskListing {
 		if !strings.Contains(taskName, ":") || lastSegment(taskName) != name {
 			continue
 		}
-		task := tf.Tasks[taskName]
-		desc, _, _ := strings.Cut(task.Desc, "\n")
-		row := taskListing{name: taskName, desc: strings.TrimSpace(desc)}
-		if len(task.Aliases) > 0 {
-			row.aliases = "(aliases: " + strings.Join(task.Aliases, ", ") + ")"
-		}
-		matches = append(matches, row)
+		matches = append(matches, newTaskListing(taskName, tf.Tasks[taskName]))
 	}
 	return matches
 }

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -214,11 +214,7 @@ func (l *includeLoader) loadIncludeDotenv(included *includedConfig) error {
 	if err != nil {
 		return fmt.Errorf("loading dotenv for include %q from %s: %w", included.Namespace, included.Parent.parentFile(), err)
 	}
-	for k, v := range childDotenv {
-		if _, exists := l.dotenvVars[k]; !exists {
-			l.dotenvVars[k] = v
-		}
-	}
+	l.dotenvVars = mergeFirstWins(l.dotenvVars, childDotenv)
 	return nil
 }
 
@@ -276,11 +272,7 @@ func (l *includeLoader) loadFlatten(req flattenRequest) error {
 	if err != nil {
 		return fmt.Errorf("loading dotenv for flatten %q from %s: %w", req.path, req.parentFile, err)
 	}
-	for k, v := range childDotenv {
-		if _, exists := l.dotenvVars[k]; !exists {
-			l.dotenvVars[k] = v
-		}
-	}
+	l.dotenvVars = mergeFirstWins(l.dotenvVars, childDotenv)
 
 	// Recurse: nested flatten files keep the same namespace and ancestor.
 	for _, p := range flattened.Flatten {
@@ -318,6 +310,24 @@ func namespaceJoin(prefix, name string) string {
 	return prefix + ":" + name
 }
 
+// mergeFirstWins copies entries from src into dst, keeping existing dst
+// entries on a key collision ("first defined wins"). It allocates dst when
+// nil and returns the (possibly new) map.
+func mergeFirstWins[V any](dst, src map[string]V) map[string]V {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]V, len(src))
+	}
+	for k, v := range src {
+		if _, exists := dst[k]; !exists {
+			dst[k] = v
+		}
+	}
+	return dst
+}
+
 // mergeVars merges vars declared by an included or flattened file into the
 // scope that owns them. Vars from the root or root-level flatten files
 // (namespace "") land in Config.Vars and are visible everywhere; vars from
@@ -331,61 +341,25 @@ func (l *includeLoader) mergeVars(namespace, dir string, vars map[string]Var) {
 		return
 	}
 	if namespace == "" {
-		if l.root.Vars == nil {
-			l.root.Vars = make(map[string]Var)
-		}
-		for k, v := range vars {
-			if _, exists := l.root.Vars[k]; !exists {
-				l.root.Vars[k] = v
-			}
-		}
+		l.root.Vars = mergeFirstWins(l.root.Vars, vars)
 		return
 	}
 	if _, ok := l.root.NamespaceDirs[namespace]; !ok {
 		l.root.NamespaceDirs[namespace] = dir
 	}
-	scoped := l.root.NamespaceVars[namespace]
-	if scoped == nil {
-		scoped = make(map[string]Var)
-		l.root.NamespaceVars[namespace] = scoped
-	}
-	for k, v := range vars {
-		if _, exists := scoped[k]; !exists {
-			scoped[k] = v
-		}
-	}
+	l.root.NamespaceVars[namespace] = mergeFirstWins(l.root.NamespaceVars[namespace], vars)
 }
 
 // mergeSourcePresets merges child source presets into the root. Root presets
 // win conflicts, mirroring the precedence used by mergeVars.
 func (l *includeLoader) mergeSourcePresets(presets map[string]StringList) {
-	if len(presets) == 0 {
-		return
-	}
-	if l.root.Sources == nil {
-		l.root.Sources = make(map[string]StringList)
-	}
-	for k, v := range presets {
-		if _, exists := l.root.Sources[k]; !exists {
-			l.root.Sources[k] = v
-		}
-	}
+	l.root.Sources = mergeFirstWins(l.root.Sources, presets)
 }
 
 // mergeSecrets merges child secret declarations into the root. Root entries
 // win conflicts, mirroring the precedence used by mergeVars.
 func (l *includeLoader) mergeSecrets(secrets map[string]string) {
-	if len(secrets) == 0 {
-		return
-	}
-	if l.root.Secrets == nil {
-		l.root.Secrets = make(map[string]string)
-	}
-	for k, v := range secrets {
-		if _, exists := l.root.Secrets[k]; !exists {
-			l.root.Secrets[k] = v
-		}
-	}
+	l.root.Secrets = mergeFirstWins(l.root.Secrets, secrets)
 }
 
 func (l *includeLoader) mergeTasks(included *includedConfig) error {

--- a/taskfile/suggest.go
+++ b/taskfile/suggest.go
@@ -1,6 +1,7 @@
 package taskfile
 
 import (
+	"maps"
 	"slices"
 )
 
@@ -25,14 +26,7 @@ func (r *Runner) suggestTasks(name string) []string {
 		return nil
 	}
 
-	type candidate struct {
-		display  string // shown to the user (task name, never the alias)
-		distance int
-	}
-
-	seen := make(map[string]int) // task name → best distance seen so far
-	var results []candidate
-
+	best := make(map[string]int) // task name → best distance across name and aliases
 	consider := func(label, taskName string) {
 		if IsInternalTask(taskName) {
 			return
@@ -41,11 +35,9 @@ func (r *Runner) suggestTasks(name string) []string {
 		if d > suggestionDistance {
 			return
 		}
-		if prev, ok := seen[taskName]; ok && prev <= d {
-			return
+		if prev, ok := best[taskName]; !ok || d < prev {
+			best[taskName] = d
 		}
-		seen[taskName] = d
-		results = append(results, candidate{display: taskName, distance: d})
 	}
 
 	for taskName := range r.tf.Tasks {
@@ -55,34 +47,13 @@ func (r *Runner) suggestTasks(name string) []string {
 		consider(alias, taskName)
 	}
 
-	// Drop entries that were superseded by a closer match for the same task.
-	results = slices.DeleteFunc(results, func(c candidate) bool {
-		return seen[c.display] != c.distance
-	})
-
-	slices.SortFunc(results, func(a, b candidate) int {
-		if a.distance != b.distance {
-			return a.distance - b.distance
-		}
-		switch {
-		case a.display < b.display:
-			return -1
-		case a.display > b.display:
-			return 1
-		default:
-			return 0
-		}
-	})
-
-	if len(results) > suggestionLimit {
-		results = results[:suggestionLimit]
+	// Closest first; the alphabetical pre-sort breaks distance ties.
+	names := slices.Sorted(maps.Keys(best))
+	slices.SortStableFunc(names, func(a, b string) int { return best[a] - best[b] })
+	if len(names) > suggestionLimit {
+		names = names[:suggestionLimit]
 	}
-
-	out := make([]string, len(results))
-	for i, c := range results {
-		out[i] = c.display
-	}
-	return out
+	return names
 }
 
 // levenshtein returns the edit distance between a and b — the minimum number

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -98,16 +98,14 @@ func (r *Runner) conditionMet(taskName, condition, dir string, env []string, use
 	}) == nil
 }
 
-// Run executes the named task. Extra vars (from task call sites) override task-level vars.
-func (r *Runner) Run(name, cliArgs string, extraVars ...map[string]Var) error {
+// Run executes the named task. Executions are memoized per resolved name, so
+// a task shared by several deps runs once. Call-site vars from `cmds:
+// - task: X` flow through runSubTask instead, which always bypasses
+// memoization.
+func (r *Runner) Run(name, cliArgs string) error {
 	resolved, err := r.resolveTask(name)
 	if err != nil {
 		return err
-	}
-
-	// Each call site with extra vars is a distinct execution — bypass memoization.
-	if hasExtraVars(extraVars) {
-		return r.run(resolved, cliArgs, extraVars, nil)
 	}
 
 	entry, _ := r.runs.LoadOrStore(resolved, &taskRun{})
@@ -135,11 +133,6 @@ func (r *Runner) runSubTask(name, cliArgs string, extraVars map[string]Var, pare
 		ev = []map[string]Var{extraVars}
 	}
 	return r.run(resolved, cliArgs, ev, parentEnv)
-}
-
-// hasExtraVars reports whether the variadic extraVars carries any overrides.
-func hasExtraVars(extraVars []map[string]Var) bool {
-	return len(extraVars) > 0 && len(extraVars[0]) > 0
 }
 
 // run executes a task's body. Deduplication is handled by Run; this method

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -204,7 +204,7 @@ func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, paren
 		return err
 	}
 
-	upToDate, checksum, err := r.isUpToDate(&task, dir, resolved, r.Force)
+	upToDate, checksum, err := r.isUpToDate(&task, dir, resolved)
 	if err != nil {
 		return err
 	}

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -98,9 +98,9 @@ func (r *Runner) conditionMet(taskName, condition, dir string, env []string, use
 	}) == nil
 }
 
-// Run executes the named task. Executions are memoized per resolved name, so
-// a task shared by several deps runs once. Call-site vars from `cmds:
-// - task: X` flow through runSubTask instead, which always bypasses
+// Run executes the named task. Executions are memoized per resolved name,
+// so a task shared by several deps runs once. Call-site vars from
+// `cmds: - task: X` flow through runSubTask instead, which always bypasses
 // memoization.
 func (r *Runner) Run(name, cliArgs string) error {
 	resolved, err := r.resolveTask(name)

--- a/taskfile/uptodate.go
+++ b/taskfile/uptodate.go
@@ -6,8 +6,8 @@ import "fmt"
 // When generates is set, it checks that all outputs exist and are newer than all sources.
 // Otherwise, it falls back to checksum-based comparison.
 // Returns whether the task is up-to-date, the current checksum (empty when using generates), and any error.
-func (r *Runner) isUpToDate(task *Task, dir, taskName string, force bool) (bool, string, error) {
-	if force || len(task.Sources) == 0 {
+func (r *Runner) isUpToDate(task *Task, dir, taskName string) (bool, string, error) {
+	if r.Force || len(task.Sources) == 0 {
 		return false, "", nil
 	}
 

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -17,13 +17,7 @@ var templatePattern = regexp.MustCompile(`\{\{\s*\.([A-Za-z_][A-Za-z0-9_]*)\s*\}
 // user-supplied string values, never YAML structure or map keys, so an env
 // value containing newlines, quotes, or `:` cannot inject new tasks/fields.
 func expandEnvTemplates(s string) string {
-	return templatePattern.ReplaceAllStringFunc(s, func(match string) string {
-		name := templatePattern.FindStringSubmatch(match)[1]
-		if val, ok := os.LookupEnv(name); ok {
-			return val
-		}
-		return match
-	})
+	return expandTemplates(s, os.LookupEnv)
 }
 
 // expandConfigEnvTemplates expands {{.VAR}} env-variable references in every


### PR DESCRIPTION
Several small pieces of the codebase had grown independently and ended up doing the same thing in slightly different ways: template expansion for env values called its own loop instead of delegating to the existing `expandTemplates`; five sites in includes.go each iterated a pair of maps to implement first-wins merging; the `--list` output and the not-found hint each built listing rows by hand; foreign-runner detection was scattered across two helpers; `isUpToDate` carried a `force` parameter that was always `false` at every call site; and `suggestTasks` deduplicated results with a slice-scan instead of a map. Each of these was harmless in isolation, but together they made the code harder to follow and changes harder to propagate.

This PR addresses all of them in small, independent steps: `expandEnvTemplates` now calls `expandTemplates`; a single generic `mergeFirstWins[K, V]` helper replaces the five duplicate loops; a `newTaskListing` constructor is shared between `--list` and the suggestion hint; a `delegateToForeign` function centralises foreign-runner discovery; the `force` parameter is removed from `isUpToDate`; `suggestTasks` uses a best-distance map; and the unused `extraVars` variadic is dropped from the exported `Runner.Run` — no in-repo callers exist. The net result is 93 insertions and 162 deletions with no behavior change.

`Runner.Run` losing its variadic `extraVars` parameter is a breaking API change for any external callers, though the function was never part of a stable public contract.