### PR TITLE
refactor: seven targeted simplifications across vars, env, and includes

### DIFF
--- a/taskfile/dotenv.go
+++ b/taskfile/dotenv.go
@@ -91,14 +91,15 @@ func isValidEnvKey(key string) bool {
 	return true
 }
 
+var dotenvUnescaper = strings.NewReplacer(`\"`, `"`, `\\`, `\`, `\n`, "\n", `\t`, "\t")
+
 // unquote removes matching surrounding quotes from a value and processes escape sequences.
 // Double-quoted values support \" and \\ escapes. Single-quoted values are literal.
 func unquote(s string) string {
 	if after, ok := strings.CutPrefix(s, `"`); ok {
 		if before, ok := strings.CutSuffix(after, `"`); ok {
 			// Process escape sequences in double-quoted strings
-			r := strings.NewReplacer(`\"`, `"`, `\\`, `\`, `\n`, "\n", `\t`, "\t")
-			return r.Replace(before)
+			return dotenvUnescaper.Replace(before)
 		}
 	}
 	if after, ok := strings.CutPrefix(s, "'"); ok {

--- a/taskfile/dotenv_test.go
+++ b/taskfile/dotenv_test.go
@@ -152,3 +152,25 @@ func TestUnquoteEscapedQuotes(t *testing.T) {
 func TestUnquoteSingleQuotesAreLiteral(t *testing.T) {
 	assert.Equal(t, `hello \"world\"`, unquote(`'hello \"world\"'`))
 }
+
+func TestUnquoteEscapeBoundaries(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "escaped newline stays literal", input: `"\\n"`, want: `\n`},
+		{name: "escaped tab stays literal", input: `"\\t"`, want: `\t`},
+		{name: "backslash before newline", input: `"\\\n"`, want: "\\\n"},
+		{name: "unknown escape stays literal", input: `"\q"`, want: `\q`},
+		{name: "trailing backslash", input: `"tail\\"`, want: `tail\`},
+		{name: "mixed escapes", input: `"\"\\\n\t"`, want: "\"\\\n\t"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, unquote(tt.input))
+		})
+	}
+}

--- a/taskfile/env.go
+++ b/taskfile/env.go
@@ -105,8 +105,7 @@ func (r *Runner) buildEnv(task *Task, dir string, parentEnv []string) ([]string,
 		}
 	}
 
-	base := slices.Clone(env)
-	resolvedTaskEnv := resolveTaskEnv(task.Env, base)
+	resolvedTaskEnv := resolveTaskEnv(task.Env, env)
 	for _, k := range slices.Sorted(maps.Keys(task.Env)) {
 		env = setEnv(env, k, resolvedTaskEnv[k])
 	}

--- a/taskfile/includes.go
+++ b/taskfile/includes.go
@@ -163,8 +163,12 @@ func (l *includeLoader) loadInclude(req includeRequest) error {
 		}
 	}
 
-	for _, nested := range nestedIncludes(included) {
-		if err := l.loadInclude(nested); err != nil {
+	for _, name := range included.Includes {
+		if err := l.loadInclude(includeRequest{
+			parentDir: included.Dir,
+			name:      name,
+			namespace: included.Namespace + ":" + name,
+		}); err != nil {
 			return err
 		}
 	}
@@ -223,18 +227,6 @@ type includedConfig struct {
 
 	Namespace string
 	Parent    includeRequest
-}
-
-func nestedIncludes(parent *includedConfig) []includeRequest {
-	var requests []includeRequest
-	for _, name := range parent.Includes {
-		requests = append(requests, includeRequest{
-			parentDir: parent.Dir,
-			name:      name,
-			namespace: parent.Namespace + ":" + name,
-		})
-	}
-	return requests
 }
 
 // flattenRequest describes a single `flatten:` entry pulled from a parent

--- a/taskfile/scoped_vars_test.go
+++ b/taskfile/scoped_vars_test.go
@@ -312,3 +312,20 @@ tasks:
 	require.Len(t, *execs, 1)
 	assert.Equal(t, "echo from-flatten", (*execs)[0].Command)
 }
+
+func TestAncestorNamespaces(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want []string
+	}{
+		{name: ""},
+		{name: "app", want: []string{"app"}},
+		{name: "app:api:build", want: []string{"app", "app:api", "app:api:build"}},
+		{name: "équipe:日本:build", want: []string{"équipe", "équipe:日本", "équipe:日本:build"}},
+		{name: ":a::", want: []string{"", ":a", ":a:", ":a::"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ancestorNamespaces(tt.name))
+		})
+	}
+}

--- a/taskfile/subtask_env_test.go
+++ b/taskfile/subtask_env_test.go
@@ -331,3 +331,21 @@ func TestParentVarsDoNotFlowDownAsEnv(t *testing.T) {
 	require.Len(t, *execs, 1)
 	assert.Empty(t, envValue((*execs)[0].Env, "PARENT_VAR"))
 }
+
+func TestBuildEnvPreservesInputSlices(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRunner(t, &Config{Dir: dir}, dir)
+	r.BaseEnv = []string{"BASE=base", "PATH=/base"}
+	parentEnv := []string{"PARENT=parent", "PATH=/parent"}
+	task := &Task{Env: map[string]string{
+		"PATH": "$PATH:/task",
+		"COPY": "$BASE:$PARENT:$PATH",
+	}}
+
+	env, err := r.buildEnv(task, dir, parentEnv)
+	require.NoError(t, err)
+	assert.Equal(t, "/parent:/task", envValue(env, "PATH"))
+	assert.Equal(t, "base:parent:/parent:/task", envValue(env, "COPY"))
+	assert.Equal(t, []string{"BASE=base", "PATH=/base"}, r.BaseEnv)
+	assert.Equal(t, []string{"PARENT=parent", "PATH=/parent"}, parentEnv)
+}

--- a/taskfile/task_execution.go
+++ b/taskfile/task_execution.go
@@ -165,17 +165,13 @@ func (r *Runner) runSubTask(name, cliArgs string, extraVars map[string]Var, pare
 	if err != nil {
 		return err
 	}
-	var ev []map[string]Var
-	if len(extraVars) > 0 {
-		ev = []map[string]Var{extraVars}
-	}
-	return r.run(resolved, cliArgs, ev, parentEnv)
+	return r.run(resolved, cliArgs, extraVars, parentEnv)
 }
 
 // run executes a task's body. Deduplication is handled by Run; this method
 // always runs the task, so recursive calls from runCmds must go through Run
 // (or runSubTask, which threads the parent env down).
-func (r *Runner) run(resolved, cliArgs string, extraVars []map[string]Var, parentEnv []string) error {
+func (r *Runner) run(resolved, cliArgs string, extraVars map[string]Var, parentEnv []string) error {
 	task := r.tf.Tasks[resolved]
 
 	if !matchesPlatform(task.Platforms) {

--- a/taskfile/transitive_vars_test.go
+++ b/taskfile/transitive_vars_test.go
@@ -291,3 +291,20 @@ func TestVarsTaskFileDirIsAlwaysAvailable(t *testing.T) {
 	}
 	assert.Equal(t, "echo "+dir+"/dist", runCmdAndCapture(t, tf))
 }
+
+func TestReferencedVarsCollectsSortedUniqueNames(t *testing.T) {
+	task := &Task{
+		Requires: Requires{Vars: StringList{"Z", "A"}},
+		Cmds: []Cmd{
+			{Cmd: "{{.B}} {{ .A }} {{.B}} $SHELL ${ENV} {{.invalid-name}}"},
+			{Defer: "{{.C}}"},
+			{If: "{{.D}}"},
+			{Task: "callee", Vars: map[string]Var{
+				"VALUE": {Value: "{{.E}} {{.A}}"},
+				"SHELL": {Sh: "echo {{.F}}"},
+			}},
+		},
+	}
+
+	assert.Equal(t, []string{"A", "B", "C", "D", "E", "F", "Z"}, referencedVars(task))
+}

--- a/taskfile/variable_expansion_test.go
+++ b/taskfile/variable_expansion_test.go
@@ -184,3 +184,33 @@ func TestLocalGitCommitVarOverridesBuiltinOnlyForTask(t *testing.T) {
 	assert.Equal(t, `echo "sha-fullsha"`, (*execs)[1].Command)
 	assert.ElementsMatch(t, []string{"git rev-parse --short=7 HEAD", "git rev-parse HEAD"}, outputs)
 }
+
+func TestUnusedVarsStaySortedAndLazy(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRunner(t, &Config{
+		Dir:  dir,
+		Vars: map[string]Var{"ROOT": {Sh: "unused root"}},
+		NamespaceVars: map[string]map[string]Var{
+			"app": {"NAMESPACE": {Sh: "unused namespace"}},
+		},
+	}, dir)
+	r.ShellRunner = &fakeShellRunner{outputFunc: func(ShellCommand) ([]byte, error) {
+		assert.Fail(t, "unused shell variable was evaluated")
+		return nil, nil
+	}}
+	task := &Task{
+		Vars: map[string]Var{
+			"Z":    {Sh: "unused task"},
+			"A":    {Sh: "unused task"},
+			"USED": {Value: "value"},
+		},
+		Cmds: []Cmd{{Cmd: "echo {{.USED}}"}},
+	}
+
+	vars, unused, err := r.resolveAllVars("app:show", task, dir, map[string]Var{
+		"M": {Sh: "unused call-site"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value", vars["USED"])
+	assert.Equal(t, []string{"A", "M", "Z"}, unused)
+}

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -221,40 +221,22 @@ func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVa
 
 func referencedVars(task *Task) []string {
 	refs := make(map[string]struct{})
+	collect := func(s string) {
+		for _, match := range templatePattern.FindAllStringSubmatch(s, -1) {
+			refs[match[1]] = struct{}{}
+		}
+	}
 	for _, name := range task.Requires.Vars {
 		refs[name] = struct{}{}
 	}
 	for _, cmd := range task.Cmds {
-		for _, name := range templateNames(cmd.Cmd) {
-			refs[name] = struct{}{}
-		}
-		for _, name := range templateNames(cmd.Defer) {
-			refs[name] = struct{}{}
-		}
-		for _, name := range templateNames(cmd.If) {
-			refs[name] = struct{}{}
-		}
+		collect(cmd.Cmd)
+		collect(cmd.Defer)
+		collect(cmd.If)
 		for _, v := range cmd.Vars {
-			for _, name := range templateNames(v.Value) {
-				refs[name] = struct{}{}
-			}
-			for _, name := range templateNames(v.Sh) {
-				refs[name] = struct{}{}
-			}
+			collect(v.Value)
+			collect(v.Sh)
 		}
-	}
-	out := slices.Sorted(maps.Keys(refs))
-	return out
-}
-
-func templateNames(s string) []string {
-	matches := templatePattern.FindAllStringSubmatch(s, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-	refs := make(map[string]struct{}, len(matches))
-	for _, match := range matches {
-		refs[match[1]] = struct{}{}
 	}
 	return slices.Sorted(maps.Keys(refs))
 }

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -115,7 +115,7 @@ func ancestorNamespaces(ns string) []string {
 // (most-specific wins) > root global. Within each layer the value is
 // template-expanded against everything below it, then against the built-in
 // lookup (e.g. {{.GIT_COMMIT}}).
-func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVars []map[string]Var) (map[string]string, []string, error) {
+func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVars map[string]Var) (map[string]string, []string, error) {
 	type sourceScope int
 
 	const (
@@ -149,10 +149,8 @@ func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVa
 	for k, v := range task.Vars {
 		sources[k] = source{v: v, dir: dir, scope: scopeTask}
 	}
-	for _, ev := range extraVars {
-		for k, v := range ev {
-			sources[k] = source{v: v, dir: dir, scope: scopeExtra}
-		}
+	for k, v := range extraVars {
+		sources[k] = source{v: v, dir: dir, scope: scopeExtra}
 	}
 
 	resolved := map[string]string{

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -98,12 +98,13 @@ func ancestorNamespaces(ns string) []string {
 	if ns == "" {
 		return nil
 	}
-	parts := strings.Split(ns, ":")
-	out := make([]string, 0, len(parts))
-	for i := 1; i <= len(parts); i++ {
-		out = append(out, strings.Join(parts[:i], ":"))
+	var out []string
+	for i, c := range ns {
+		if c == ':' {
+			out = append(out, ns[:i])
+		}
 	}
-	return out
+	return append(out, ns)
 }
 
 // resolveAllVars computes the variables that are actually used by a task.

--- a/taskfile/vars.go
+++ b/taskfile/vars.go
@@ -208,8 +208,7 @@ func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVa
 	}
 
 	unused := make([]string, 0)
-	for _, name := range slices.Sorted(maps.Keys(sources)) {
-		s := sources[name]
+	for name, s := range sources {
 		if s.scope != scopeTask && s.scope != scopeExtra {
 			continue
 		}
@@ -217,6 +216,7 @@ func (r *Runner) resolveAllVars(taskName string, task *Task, dir string, extraVa
 			unused = append(unused, name)
 		}
 	}
+	slices.Sort(unused)
 	return resolved, unused, nil
 }
 


### PR DESCRIPTION
The vars and includes subsystems had accumulated a handful of small abstractions — helpers, intermediate maps, cloned slices — that no longer pulled their weight. Each made a small piece of logic harder to follow without adding correctness or safety.

This series of seven independent, behavior-preserving commits tightens those areas. Call-site vars are now passed directly as `map[string]string` instead of through a slice-of-maps abstraction. Template refs are collected into one shared set rather than through a dedicated helper. The `nestedIncludes` traversal is inlined. An env clone that happened just before a read-only call is removed. The dotenv unescaping reuses a package-level `strings.Replacer`. `ancestorNamespaces` now slices the string rather than splitting and rejoining. And unused-variable warning candidates are sorted only once, at the point they're actually needed, rather than over the full source-key set.

No behaviour changes. Regression tests were added for the dotenv unescaping, namespaced-var isolation, sub-task env propagation, and transitive variable expansion to pin the areas touched.